### PR TITLE
Augment findings metadata with file path.

### DIFF
--- a/agent/semgrep_agent.py
+++ b/agent/semgrep_agent.py
@@ -162,6 +162,7 @@ class SemgrepAgent(agent.Agent, agent_report_vulnerability_mixin.AgentReportVuln
                 entry=vuln.entry,
                 technical_detail=vuln.technical_detail,
                 risk_rating=vuln.risk_rating,
+                vulnerability_location=vuln.vulnerability_location,
             )
 
 

--- a/agent/semgrep_agent.py
+++ b/agent/semgrep_agent.py
@@ -120,6 +120,8 @@ class SemgrepAgent(agent.Agent, agent_report_vulnerability_mixin.AgentReportVuln
         if file_type in FILE_TYPE_BLACKLIST:
             logger.debug("File type is blacklisted.")
             return
+        bundle_id = message.data.get("ios_metadata", {}).get("bundle_id")
+        package_name = message.data.get("android_metadata", {}).get("package_name")
 
         with tempfile.NamedTemporaryFile(suffix=file_type) as infile:
             if path is not None and path.endswith(".js") is True:
@@ -149,14 +151,25 @@ class SemgrepAgent(agent.Agent, agent_report_vulnerability_mixin.AgentReportVuln
             if isinstance(stdout, bytes) and len(stderr) == 0:
                 json_output = json.loads(stdout)
                 json_output["path"] = path
-                self._emit_results(json_output)
+                self._emit_results(
+                    json_output=json_output,
+                    package_name=package_name,
+                    bundle_id=bundle_id,
+                )
                 logger.debug("Semgrep completed without errors.")
             else:
                 logger.error("Semgrep completed with errors %s", stderr)
 
-    def _emit_results(self, json_output: dict[str, Any]) -> None:
+    def _emit_results(
+        self,
+        json_output: dict[str, Any],
+        package_name: str | None = None,
+        bundle_id: str | None = None,
+    ) -> None:
         """Parses results and emits vulnerabilities."""
-        for vuln in utils.parse_results(json_output):
+        for vuln in utils.parse_results(
+            json_output=json_output, package_name=package_name, bundle_id=bundle_id
+        ):
             logger.info("Found vulnerability: %s", vuln)
             self.report_vulnerability(
                 entry=vuln.entry,

--- a/agent/utils.py
+++ b/agent/utils.py
@@ -38,6 +38,9 @@ class Vulnerability:
     entry: kb.Entry
     technical_detail: str
     risk_rating: agent_report_vulnerability_mixin.RiskRating
+    vulnerability_location: (
+        agent_report_vulnerability_mixin.VulnerabilityLocation | None
+    ) = None
 
 
 def construct_technical_detail(vulnerability: dict[str, Any], path: str) -> str:
@@ -118,6 +121,17 @@ def parse_results(json_output: dict[str, Any]) -> Iterator[Vulnerability]:
         }
 
         technical_detail = construct_technical_detail(vulnerability, path)
+        path = path or vulnerability.get("path")
+        vulnerability_location = None
+        if path is not None:
+            vulnerability_location = agent_report_vulnerability_mixin.VulnerabilityLocation(
+                metadata=[
+                    agent_report_vulnerability_mixin.VulnerabilityLocationMetadata(
+                        metadata_type=agent_report_vulnerability_mixin.MetadataType.FILE_PATH,
+                        value=path,
+                    )
+                ]
+            )
 
         yield Vulnerability(
             entry=kb.Entry(
@@ -136,6 +150,7 @@ def parse_results(json_output: dict[str, Any]) -> Iterator[Vulnerability]:
             ),
             technical_detail=technical_detail,
             risk_rating=RISK_RATING_MAPPING[impact],
+            vulnerability_location=vulnerability_location,
         )
 
 

--- a/agent/utils.py
+++ b/agent/utils.py
@@ -13,8 +13,13 @@ from urllib import parse
 import tenacity
 import magic
 from ostorlab.agent.kb import kb
-from ostorlab.agent.mixins import agent_report_vulnerability_mixin
+from ostorlab.agent.mixins import (
+    agent_report_vulnerability_mixin as vulnerability_mixin,
+)
 from ostorlab.agent.message import message as m
+from ostorlab.assets import asset as os_asset
+from ostorlab.assets import ios_store
+from ostorlab.assets import android_store
 
 
 LINE_SIZE_MAX = 5000
@@ -22,10 +27,10 @@ DOWNLOAD_REQUEST_TIMEOUT = 60
 NUMBER_RETRIES = 3
 
 RISK_RATING_MAPPING = {
-    "UNKNOWN": agent_report_vulnerability_mixin.RiskRating.POTENTIALLY,
-    "LOW": agent_report_vulnerability_mixin.RiskRating.LOW,
-    "MEDIUM": agent_report_vulnerability_mixin.RiskRating.MEDIUM,
-    "HIGH": agent_report_vulnerability_mixin.RiskRating.HIGH,
+    "UNKNOWN": vulnerability_mixin.RiskRating.POTENTIALLY,
+    "LOW": vulnerability_mixin.RiskRating.LOW,
+    "MEDIUM": vulnerability_mixin.RiskRating.MEDIUM,
+    "HIGH": vulnerability_mixin.RiskRating.HIGH,
 }
 
 logger = logging.getLogger(__name__)
@@ -37,10 +42,8 @@ class Vulnerability:
 
     entry: kb.Entry
     technical_detail: str
-    risk_rating: agent_report_vulnerability_mixin.RiskRating
-    vulnerability_location: (
-        agent_report_vulnerability_mixin.VulnerabilityLocation | None
-    ) = None
+    risk_rating: vulnerability_mixin.RiskRating
+    vulnerability_location: vulnerability_mixin.VulnerabilityLocation | None = None
 
 
 def construct_technical_detail(vulnerability: dict[str, Any], path: str) -> str:
@@ -95,11 +98,40 @@ def filter_description(description: str) -> str:
     return description
 
 
-def parse_results(json_output: dict[str, Any]) -> Iterator[Vulnerability]:
+def _prepare_vulnerability_location(
+    file_path: str, package_name: str | None = None, bundle_id: str | None = None
+) -> vulnerability_mixin.VulnerabilityLocation | None:
+    """Prepare a `VulnerabilityLocation` instance with iOS asset & its Bundle ID, with file path as vulnerability metadata."""
+    if bundle_id is None and package_name is None:
+        return None
+    asset: os_asset.Asset | None = None
+    if bundle_id is not None:
+        asset = ios_store.IOSStore(bundle_id=bundle_id)
+    if package_name is not None:
+        asset = android_store.AndroidStore(package_name=package_name)
+
+    return vulnerability_mixin.VulnerabilityLocation(
+        asset=asset,
+        metadata=[
+            vulnerability_mixin.VulnerabilityLocationMetadata(
+                metadata_type=vulnerability_mixin.MetadataType.FILE_PATH,
+                value=file_path,
+            )
+        ],
+    )
+
+
+def parse_results(
+    json_output: dict[str, Any],
+    package_name: str | None = None,
+    bundle_id: str | None = None,
+) -> Iterator[Vulnerability]:
     """Parses JSON generated Semgrep results and yield vulnerability entries.
 
     Args:
         json_output: Semgrep json output.
+        package_name: optional application package name to augment the vulnerability location.
+        bundle_id: optional bundle identifier to augment the vulnerability location.
 
     Yields:
         Vulnerability entry.
@@ -124,13 +156,8 @@ def parse_results(json_output: dict[str, Any]) -> Iterator[Vulnerability]:
         path = path or vulnerability.get("path")
         vulnerability_location = None
         if path is not None:
-            vulnerability_location = agent_report_vulnerability_mixin.VulnerabilityLocation(
-                metadata=[
-                    agent_report_vulnerability_mixin.VulnerabilityLocationMetadata(
-                        metadata_type=agent_report_vulnerability_mixin.MetadataType.FILE_PATH,
-                        value=path,
-                    )
-                ]
+            vulnerability_location = _prepare_vulnerability_location(
+                file_path=path, package_name=package_name, bundle_id=bundle_id
             )
 
         yield Vulnerability(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -80,7 +80,11 @@ def scan_message_file() -> message.Message:
     selector = "v3.asset.file"
     path = "tests/files/vulnerable.java"
     with open(path, "rb") as infile:
-        msg_data = {"content": infile.read(), "path": path}
+        msg_data = {
+            "content": infile.read(),
+            "path": path,
+            "android_metadata": {"package_name": "a.b.c"},
+        }
     return message.Message.from_data(selector, data=msg_data)
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -89,6 +89,20 @@ def scan_message_file() -> message.Message:
 
 
 @pytest.fixture
+def ios_scan_message_file() -> message.Message:
+    """Creates a dummy message of type v3.asset.file to be used by the agent for testing purposes."""
+    selector = "v3.asset.file"
+    path = "tests/files/vulnerable.java"
+    with open(path, "rb") as infile:
+        msg_data = {
+            "content": infile.read(),
+            "path": path,
+            "ios_metadata": {"bundle_id": "a.b.c"},
+        }
+    return message.Message.from_data(selector, data=msg_data)
+
+
+@pytest.fixture
 def scan_message_js_file() -> message.Message:
     """Creates a dummy message of type v3.asset.file to be used by the agent for testing purposes."""
     selector = "v3.asset.file"

--- a/tests/semgrep_agent_test.py
+++ b/tests/semgrep_agent_test.py
@@ -174,6 +174,12 @@ def testAgentSemgrep_whenAnalysisRunsWithoutErrors_emitsBackVulnerability(
         "Cipher cipher = Cipher.getInstance('AES/CBC/PKCS5Padding');\n"
         "```"
     )
+    assert vuln["vulnerability_location"] is not None
+    assert vuln["vulnerability_location"]["metadata"][0]["type"] == "FILE_PATH"
+    assert (
+        vuln["vulnerability_location"]["metadata"][0]["value"]
+        == "tests/files/vulnerable.java"
+    )
 
 
 def testAgentSemgrep_whenAnalysisRunsWithoutPathWithoutErrors_emitsBackVulnerability(

--- a/tests/semgrep_agent_test.py
+++ b/tests/semgrep_agent_test.py
@@ -398,3 +398,35 @@ def testAgentSemgrep_whenValidMessage_constructCorrectCommand(
     assert command_mock.call_args.args[0][10] == "--max-memory"
     assert command_mock.call_args.args[0][11] == "2147483648"
     assert command_mock.call_args.args[0][12] == "--json"
+
+
+def testAgentSemgrep_whenIosAsset_addsIosAssetToVulnLocation(
+    test_agent: semgrep_agent.SemgrepAgent,
+    agent_mock: list[message.Message],
+    agent_persist_mock: dict[str | bytes, str | bytes],
+    ios_scan_message_file: message.Message,
+    mocker: plugin.MockerFixture,
+) -> None:
+    """Unit test for the full life cycle of the agent:
+    case where the semgrep analysis runs without errors and yields vulnerabilities.
+    """
+    mocker.patch(
+        "agent.semgrep_agent._run_analysis",
+        return_value=(JSON_OUTPUT, EMPTY_ERROR_MESSAGE),
+    )
+
+    test_agent.process(ios_scan_message_file)
+    vuln = agent_mock[0].data
+
+    assert vuln["title"] == "Cbc Padding Oracle"
+    assert vuln["risk_rating"] == "MEDIUM"
+    assert vuln["recommendation"] == "AES/GCM/NoPadding"
+    assert vuln["security_issue"] is True
+    assert vuln["vulnerability_location"] is not None
+    assert vuln["vulnerability_location"]["metadata"][0]["type"] == "FILE_PATH"
+    assert (
+        vuln["vulnerability_location"]["metadata"][0]["value"]
+        == "tests/files/vulnerable.java"
+    )
+    assert vuln["vulnerability_location"]["ios_store"] is not None
+    assert vuln["vulnerability_location"]["ios_store"]["bundle_id"] == "a.b.c"

--- a/tests/semgrep_agent_test.py
+++ b/tests/semgrep_agent_test.py
@@ -180,6 +180,8 @@ def testAgentSemgrep_whenAnalysisRunsWithoutErrors_emitsBackVulnerability(
         vuln["vulnerability_location"]["metadata"][0]["value"]
         == "tests/files/vulnerable.java"
     )
+    assert vuln["vulnerability_location"]["android_store"] is not None
+    assert vuln["vulnerability_location"]["android_store"]["package_name"] == "a.b.c"
 
 
 def testAgentSemgrep_whenAnalysisRunsWithoutPathWithoutErrors_emitsBackVulnerability(


### PR DESCRIPTION
What:Part of the Ostorlab Security Scanner Github application, This PR adds information about the file where the findings was detected as metadata.
Why: Because we needed information about the file to be able to map it to the file path on the Pull Request raw code on Github.
How: Simply create instances of `VulnerabilityLocation`, where the metadata list contains an element with type `FILE_PATH` & value is the actual path where the vulnerability was detected 