### PR TITLE
Compute vulnerability dna

### DIFF
--- a/agent/semgrep_agent.py
+++ b/agent/semgrep_agent.py
@@ -176,6 +176,7 @@ class SemgrepAgent(agent.Agent, agent_report_vulnerability_mixin.AgentReportVuln
                 technical_detail=vuln.technical_detail,
                 risk_rating=vuln.risk_rating,
                 vulnerability_location=vuln.vulnerability_location,
+                dna=vuln.vuln_dna,
             )
 
 

--- a/agent/utils.py
+++ b/agent/utils.py
@@ -121,20 +121,20 @@ def _sort_dict(dictionary: dict[str, Any] | list[Any]) -> dict[str, Any] | list[
 
 def _compute_vulnerability_dna(
     title: str,
-    technical_detail: str,
+    lines: str,
     vulnerability_location: vulnerability_mixin.VulnerabilityLocation | None,
 ) -> str:
     """Compute a deterministic, debuggable DNA representation for a vulnerability.
     Args:
         title: Generate KB title.
-        technical_detail: the detail of the vulnerability including the lines of code and affected file name.
+        lines: the lines where the vulnerability was detected.
         vulnerability_location: the computed vulnerability location.
     Returns:
         A deterministic JSON representation of the vulnerability DNA.
     """
     dna_data: dict[str, Any] = {
         "title": title,
-        "technical_detail": technical_detail,
+        "lines": lines,
     }
 
     if vulnerability_location is not None:
@@ -206,6 +206,7 @@ def parse_results(
             vulnerability_location = _prepare_vulnerability_location(
                 file_path=path, package_name=package_name, bundle_id=bundle_id
             )
+        lines = vulnerability["extra"].get("lines", "").strip()[:LINE_SIZE_MAX]
 
         yield Vulnerability(
             entry=kb.Entry(
@@ -225,9 +226,7 @@ def parse_results(
             technical_detail=technical_detail,
             risk_rating=RISK_RATING_MAPPING[impact],
             vulnerability_location=vulnerability_location,
-            vuln_dna=_compute_vulnerability_dna(
-                title, technical_detail, vulnerability_location
-            ),
+            vuln_dna=_compute_vulnerability_dna(title, lines, vulnerability_location),
         )
 
 

--- a/agent/utils.py
+++ b/agent/utils.py
@@ -8,6 +8,7 @@ import os
 import re
 from typing import Any, Iterator
 from urllib import parse
+import json
 
 
 import tenacity
@@ -43,6 +44,7 @@ class Vulnerability:
     entry: kb.Entry
     technical_detail: str
     risk_rating: vulnerability_mixin.RiskRating
+    vuln_dna: str
     vulnerability_location: vulnerability_mixin.VulnerabilityLocation | None = None
 
 
@@ -96,6 +98,51 @@ def filter_description(description: str) -> str:
         description,
     )
     return description
+
+
+def _sort_dict(dictionary: dict[str, Any] | list[Any]) -> dict[str, Any] | list[Any]:
+    """Recursively sort dictionary keys and lists within.
+    Args:
+        dictionary: The dictionary to sort.
+    Returns:
+        A sorted dictionary or list.
+    """
+    if isinstance(dictionary, dict):
+        return {k: _sort_dict(v) for k, v in sorted(dictionary.items())}
+    if isinstance(dictionary, list):
+        return sorted(
+            dictionary,
+            key=lambda x: json.dumps(x, sort_keys=True)
+            if isinstance(x, dict)
+            else str(x),
+        )
+    return dictionary
+
+
+def _compute_vulnerability_dna(
+    title: str,
+    technical_detail: str,
+    vulnerability_location: vulnerability_mixin.VulnerabilityLocation,
+) -> str:
+    """Compute a deterministic, debuggable DNA representation for a vulnerability.
+    Args:
+        title: Generate KB title.
+        technical_detail: the detail of the vulnerability including the lines of code and affected file name.
+        vulnerability_location: the computed vulnerability location.
+    Returns:
+        A deterministic JSON representation of the vulnerability DNA.
+    """
+    dna_data: dict[str, Any] = {
+        "title": title,
+        "technical_detail": technical_detail,
+    }
+
+    if vulnerability_location is not None:
+        location_dict: dict[str, Any] = vulnerability_location.to_dict()
+        sorted_location_dict = _sort_dict(location_dict)
+        dna_data["location"] = sorted_location_dict
+
+    return json.dumps(dna_data, sort_keys=True)
 
 
 def _prepare_vulnerability_location(
@@ -178,6 +225,9 @@ def parse_results(
             technical_detail=technical_detail,
             risk_rating=RISK_RATING_MAPPING[impact],
             vulnerability_location=vulnerability_location,
+            vuln_dna=_compute_vulnerability_dna(
+                title, technical_detail, vulnerability_location
+            ),
         )
 
 

--- a/agent/utils.py
+++ b/agent/utils.py
@@ -122,7 +122,7 @@ def _sort_dict(dictionary: dict[str, Any] | list[Any]) -> dict[str, Any] | list[
 def _compute_vulnerability_dna(
     title: str,
     technical_detail: str,
-    vulnerability_location: vulnerability_mixin.VulnerabilityLocation,
+    vulnerability_location: vulnerability_mixin.VulnerabilityLocation | None,
 ) -> str:
     """Compute a deterministic, debuggable DNA representation for a vulnerability.
     Args:

--- a/tests/semgrep_agent_test.py
+++ b/tests/semgrep_agent_test.py
@@ -183,14 +183,9 @@ def testAgentSemgrep_whenAnalysisRunsWithoutErrors_emitsBackVulnerability(
     assert vuln["vulnerability_location"]["android_store"] is not None
     assert vuln["vulnerability_location"]["android_store"]["package_name"] == "a.b.c"
     assert vuln["dna"] == (
-        '{"location": {"android_store": {"package_name": "a.b.c"}, "metadata": [{"type": "FILE_PATH'
-        '", "value": "tests/files/vulnerable.java"}]}, "technical_detail": "Cbc Padding Oracle: Usi'
-        "ng CBC with PKCS5Padding is susceptible to padding oracle attacks. A malicious actor could"
-        " discern the difference between plaintext with valid or invalid padding. Further, CBC mode"
-        " does not include any integrity checks. Use 'AES/GCM/NoPadding' instead.\\n    \\nThe iss"
-        "ue was detected in `tests/files/vulnerable.java`, line `28`, column `44`, below is a code s"
-        "nippet from the vulnerable code\\n```java\\nCipher cipher = Cipher.getInstance('AES/CBC/PK"
-        'CS5Padding\');\\n```", "title": "Cbc Padding Oracle"}'
+        '{"lines": "Cipher cipher = Cipher.getInstance(\'AES/CBC/PKCS5Padding\');", "location": {"android_store": '
+        '{"package_name": "a.b.c"}, "metadata": [{"type": "FILE_PATH", "value": "tests/files/vulnerable.java"}]}, '
+        '"title": "Cbc Padding Oracle"}'
     )
 
 
@@ -262,15 +257,9 @@ def testAgentSemgrep_whenAnalysisRunsWithoutPathWithoutErrors_emitsBackVulnerabi
         "```"
     )
     assert vuln["dna"] == (
-        '{"location": {"android_store": {"package_name": "a.b.c"}, "metadata": '
-        '[{"type": "FILE_PATH", "value": "/tmp/tmpza6g8qu0.java"}]}, "technical_detail": '
-        '"Cbc Padding Oracle: Using CBC with PKCS5Padding is susceptible to padding oracle '
-        "attacks. A malicious actor could discern the difference between plaintext with valid o"
-        "r invalid padding. Further, CBC mode does not include any integrity checks. Use 'AES/"
-        "GCM/NoPadding' instead.\\n    \\nThe issue was detected in `/tmp/tmpza6g8qu0.java`, "
-        "line `28`, column `44`, below is a code snippet from the vulnerable code\\n```java\\nC"
-        'ipher cipher = Cipher.getInstance(\'AES/CBC/PKCS5Padding\');\\n```", "title": "Cbc Pad'
-        'ding Oracle"}'
+        '{"lines": "Cipher cipher = Cipher.getInstance(\'AES/CBC/PKCS5Padding\');", "location": {"android_store":'
+        ' {"package_name": "a.b.c"}, "metadata": [{"type": "FILE_PATH", "value": "/tmp/tmpza6g8qu0.java"}]}, "tit'
+        'le": "Cbc Padding Oracle"}'
     )
 
 
@@ -452,12 +441,7 @@ def testAgentSemgrep_whenIosAsset_addsIosAssetToVulnLocation(
     assert vuln["vulnerability_location"]["ios_store"] is not None
     assert vuln["vulnerability_location"]["ios_store"]["bundle_id"] == "a.b.c"
     assert vuln["dna"] == (
-        '{"location": {"ios_store": {"bundle_id": "a.b.c"}, "metadata": [{"type": "FILE_PATH", '
-        '"value": "tests/files/vulnerable.java"}]}, "technical_detail": "Cbc Padding Oracle: Using'
-        " CBC with PKCS5Padding is susceptible to padding oracle attacks. A malicious actor could "
-        "discern the difference between plaintext with valid or invalid padding. Further, CBC mode"
-        " does not include any integrity checks. Use 'AES/GCM/NoPadding' instead.\\n    \\nThe i"
-        "ssue was detected in `tests/files/vulnerable.java`, line `28`, column `44`, below is a co"
-        "de snippet from the vulnerable code\\n```java\\nCipher cipher = Cipher.getInstance('AES/"
-        'CBC/PKCS5Padding\');\\n```", "title": "Cbc Padding Oracle"}'
+        '{"lines": "Cipher cipher = Cipher.getInstance(\'AES/CBC/PKCS5Padding\');", "location": {"ios_store": '
+        '{"bundle_id": "a.b.c"}, "metadata": [{"type": "FILE_PATH", "value": "tests/files/vulnerable.java"}]}, '
+        '"title": "Cbc Padding Oracle"}'
     )

--- a/tests/semgrep_agent_test.py
+++ b/tests/semgrep_agent_test.py
@@ -182,6 +182,16 @@ def testAgentSemgrep_whenAnalysisRunsWithoutErrors_emitsBackVulnerability(
     )
     assert vuln["vulnerability_location"]["android_store"] is not None
     assert vuln["vulnerability_location"]["android_store"]["package_name"] == "a.b.c"
+    assert vuln["dna"] == (
+        '{"location": {"android_store": {"package_name": "a.b.c"}, "metadata": [{"type": "FILE_PATH'
+        '", "value": "tests/files/vulnerable.java"}]}, "technical_detail": "Cbc Padding Oracle: Usi'
+        "ng CBC with PKCS5Padding is susceptible to padding oracle attacks. A malicious actor could"
+        " discern the difference between plaintext with valid or invalid padding. Further, CBC mode"
+        " does not include any integrity checks. Use 'AES/GCM/NoPadding' instead.\\n    \\nThe iss"
+        "ue was detected in `tests/files/vulnerable.java`, line `28`, column `44`, below is a code s"
+        "nippet from the vulnerable code\\n```java\\nCipher cipher = Cipher.getInstance('AES/CBC/PK"
+        'CS5Padding\');\\n```", "title": "Cbc Padding Oracle"}'
+    )
 
 
 def testAgentSemgrep_whenAnalysisRunsWithoutPathWithoutErrors_emitsBackVulnerability(
@@ -250,6 +260,17 @@ def testAgentSemgrep_whenAnalysisRunsWithoutPathWithoutErrors_emitsBackVulnerabi
         "```java\n"
         "Cipher cipher = Cipher.getInstance('AES/CBC/PKCS5Padding');\n"
         "```"
+    )
+    assert vuln["dna"] == (
+        '{"location": {"android_store": {"package_name": "a.b.c"}, "metadata": '
+        '[{"type": "FILE_PATH", "value": "/tmp/tmpza6g8qu0.java"}]}, "technical_detail": '
+        '"Cbc Padding Oracle: Using CBC with PKCS5Padding is susceptible to padding oracle '
+        "attacks. A malicious actor could discern the difference between plaintext with valid o"
+        "r invalid padding. Further, CBC mode does not include any integrity checks. Use 'AES/"
+        "GCM/NoPadding' instead.\\n    \\nThe issue was detected in `/tmp/tmpza6g8qu0.java`, "
+        "line `28`, column `44`, below is a code snippet from the vulnerable code\\n```java\\nC"
+        'ipher cipher = Cipher.getInstance(\'AES/CBC/PKCS5Padding\');\\n```", "title": "Cbc Pad'
+        'ding Oracle"}'
     )
 
 
@@ -430,3 +451,13 @@ def testAgentSemgrep_whenIosAsset_addsIosAssetToVulnLocation(
     )
     assert vuln["vulnerability_location"]["ios_store"] is not None
     assert vuln["vulnerability_location"]["ios_store"]["bundle_id"] == "a.b.c"
+    assert vuln["dna"] == (
+        '{"location": {"ios_store": {"bundle_id": "a.b.c"}, "metadata": [{"type": "FILE_PATH", '
+        '"value": "tests/files/vulnerable.java"}]}, "technical_detail": "Cbc Padding Oracle: Using'
+        " CBC with PKCS5Padding is susceptible to padding oracle attacks. A malicious actor could "
+        "discern the difference between plaintext with valid or invalid padding. Further, CBC mode"
+        " does not include any integrity checks. Use 'AES/GCM/NoPadding' instead.\\n    \\nThe i"
+        "ssue was detected in `tests/files/vulnerable.java`, line `28`, column `44`, below is a co"
+        "de snippet from the vulnerable code\\n```java\\nCipher cipher = Cipher.getInstance('AES/"
+        'CBC/PKCS5Padding\');\\n```", "title": "Cbc Padding Oracle"}'
+    )


### PR DESCRIPTION
This PR computes and adds the dna attribute to the semgrep agent:
dna schema:
```json
{
    "lines": "the affected lines in file affected by the vuln.",
    "location": "dict value of the vulnerability location",
    "title": "vulnerability title given by semgrep"
}
```