### PR TITLE
feature: add harmonyos support

### DIFF
--- a/agent/semgrep_agent.py
+++ b/agent/semgrep_agent.py
@@ -109,6 +109,9 @@ class SemgrepAgent(agent.Agent, agent_report_vulnerability_mixin.AgentReportVuln
 
         bundle_id = message.data.get("ios_metadata", {}).get("bundle_id")
         package_name = message.data.get("android_metadata", {}).get("package_name")
+        harmony_bundle_name = message.data.get("harmonyos_metadata", {}).get(
+            "bundle_name"
+        )
 
         with tempfile.NamedTemporaryFile(suffix=file_type) as infile:
             if path is not None and path.endswith(".js") is True:
@@ -142,6 +145,7 @@ class SemgrepAgent(agent.Agent, agent_report_vulnerability_mixin.AgentReportVuln
                     json_output=json_output,
                     package_name=package_name,
                     bundle_id=bundle_id,
+                    harmony_bundle_name=harmony_bundle_name,
                 )
                 logger.debug("Semgrep completed without errors.")
             else:
@@ -152,10 +156,14 @@ class SemgrepAgent(agent.Agent, agent_report_vulnerability_mixin.AgentReportVuln
         json_output: dict[str, Any],
         package_name: str | None = None,
         bundle_id: str | None = None,
+        harmony_bundle_name: str | None = None,
     ) -> None:
         """Parses results and emits vulnerabilities."""
         for vuln in utils.parse_results(
-            json_output=json_output, package_name=package_name, bundle_id=bundle_id
+            json_output=json_output,
+            package_name=package_name,
+            bundle_id=bundle_id,
+            harmony_bundle_name=harmony_bundle_name,
         ):
             logger.info("Found vulnerability: %s", vuln)
             self.report_vulnerability(

--- a/agent/utils.py
+++ b/agent/utils.py
@@ -21,6 +21,7 @@ from ostorlab.agent.message import message as m
 from ostorlab.assets import asset as os_asset
 from ostorlab.assets import ios_store
 from ostorlab.assets import android_store
+from ostorlab.assets import harmonyos_store
 
 
 LINE_SIZE_MAX = 5000
@@ -146,16 +147,21 @@ def _compute_vulnerability_dna(
 
 
 def _prepare_vulnerability_location(
-    file_path: str, package_name: str | None = None, bundle_id: str | None = None
+    file_path: str,
+    package_name: str | None = None,
+    bundle_id: str | None = None,
+    harmony_bundle_name: str | None = None,
 ) -> vulnerability_mixin.VulnerabilityLocation | None:
-    """Prepare a `VulnerabilityLocation` instance with iOS asset & its Bundle ID, with file path as vulnerability metadata."""
-    if bundle_id is None and package_name is None:
+    """Prepare a `VulnerabilityLocation` with store asset and file path metadata."""
+    if bundle_id is None and package_name is None and harmony_bundle_name is None:
         return None
     asset: os_asset.Asset | None = None
     if bundle_id is not None:
         asset = ios_store.IOSStore(bundle_id=bundle_id)
     if package_name is not None:
         asset = android_store.AndroidStore(package_name=package_name)
+    if harmony_bundle_name is not None:
+        asset = harmonyos_store.HarmonyOSStore(bundle_name=harmony_bundle_name)
 
     return vulnerability_mixin.VulnerabilityLocation(
         asset=asset,
@@ -172,6 +178,7 @@ def parse_results(
     json_output: dict[str, Any],
     package_name: str | None = None,
     bundle_id: str | None = None,
+    harmony_bundle_name: str | None = None,
 ) -> Iterator[Vulnerability]:
     """Parses JSON generated Semgrep results and yield vulnerability entries.
 
@@ -179,6 +186,7 @@ def parse_results(
         json_output: Semgrep json output.
         package_name: optional application package name to augment the vulnerability location.
         bundle_id: optional bundle identifier to augment the vulnerability location.
+        harmony_bundle_name: optional HarmonyOS bundle name to augment vulnerability location.
 
     Yields:
         Vulnerability entry.
@@ -204,7 +212,10 @@ def parse_results(
         vulnerability_location = None
         if path is not None:
             vulnerability_location = _prepare_vulnerability_location(
-                file_path=path, package_name=package_name, bundle_id=bundle_id
+                file_path=path,
+                package_name=package_name,
+                bundle_id=bundle_id,
+                harmony_bundle_name=harmony_bundle_name,
             )
         lines = vulnerability["extra"].get("lines", "").strip()[:LINE_SIZE_MAX]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -103,6 +103,20 @@ def ios_scan_message_file() -> message.Message:
 
 
 @pytest.fixture
+def harmonyos_scan_message_file() -> message.Message:
+    """Creates a dummy message with HarmonyOS metadata for testing purposes."""
+    selector = "v3.asset.file"
+    path = "tests/files/vulnerable.java"
+    with open(path, "rb") as infile:
+        msg_data = {
+            "content": infile.read(),
+            "path": path,
+            "harmonyos_metadata": {"bundle_name": "a.b.c"},
+        }
+    return message.Message.from_data(selector, data=msg_data)
+
+
+@pytest.fixture
 def scan_message_js_file() -> message.Message:
     """Creates a dummy message of type v3.asset.file to be used by the agent for testing purposes."""
     selector = "v3.asset.file"

--- a/tests/semgrep_agent_test.py
+++ b/tests/semgrep_agent_test.py
@@ -474,10 +474,7 @@ def testAgentSemgrep_whenHarmonyOSAsset_addsHarmonyOSAssetToVulnLocation(
         == "tests/files/vulnerable.java"
     )
     assert vuln["vulnerability_location"]["harmonyos_store"] is not None
-    assert (
-        vuln["vulnerability_location"]["harmonyos_store"]["bundle_name"]
-        == "a.b.c"
-    )
+    assert vuln["vulnerability_location"]["harmonyos_store"]["bundle_name"] == "a.b.c"
     assert vuln["dna"] == (
         '{"lines": "Cipher cipher = Cipher.getInstance(\'AES/CBC/PKCS5Padding\');", "location": {"harmonyos_store": '
         '{"bundle_name": "a.b.c"}, "metadata": [{"type": "FILE_PATH", "value": "tests/files/vulnerable.java"}]}, '

--- a/tests/semgrep_agent_test.py
+++ b/tests/semgrep_agent_test.py
@@ -445,3 +445,41 @@ def testAgentSemgrep_whenIosAsset_addsIosAssetToVulnLocation(
         '{"bundle_id": "a.b.c"}, "metadata": [{"type": "FILE_PATH", "value": "tests/files/vulnerable.java"}]}, '
         '"title": "Cbc Padding Oracle"}'
     )
+
+
+def testAgentSemgrep_whenHarmonyOSAsset_addsHarmonyOSAssetToVulnLocation(
+    test_agent: semgrep_agent.SemgrepAgent,
+    agent_mock: list[message.Message],
+    agent_persist_mock: dict[str | bytes, str | bytes],
+    harmonyos_scan_message_file: message.Message,
+    mocker: plugin.MockerFixture,
+) -> None:
+    """Unit test for the full life cycle of the agent with HarmonyOS metadata."""
+    mocker.patch(
+        "agent.semgrep_agent._run_analysis",
+        return_value=(JSON_OUTPUT, EMPTY_ERROR_MESSAGE),
+    )
+
+    test_agent.process(harmonyos_scan_message_file)
+    vuln = agent_mock[0].data
+
+    assert vuln["title"] == "Cbc Padding Oracle"
+    assert vuln["risk_rating"] == "MEDIUM"
+    assert vuln["recommendation"] == "AES/GCM/NoPadding"
+    assert vuln["security_issue"] is True
+    assert vuln["vulnerability_location"] is not None
+    assert vuln["vulnerability_location"]["metadata"][0]["type"] == "FILE_PATH"
+    assert (
+        vuln["vulnerability_location"]["metadata"][0]["value"]
+        == "tests/files/vulnerable.java"
+    )
+    assert vuln["vulnerability_location"]["harmonyos_store"] is not None
+    assert (
+        vuln["vulnerability_location"]["harmonyos_store"]["bundle_name"]
+        == "a.b.c"
+    )
+    assert vuln["dna"] == (
+        '{"lines": "Cipher cipher = Cipher.getInstance(\'AES/CBC/PKCS5Padding\');", "location": {"harmonyos_store": '
+        '{"bundle_name": "a.b.c"}, "metadata": [{"type": "FILE_PATH", "value": "tests/files/vulnerable.java"}]}, '
+        '"title": "Cbc Padding Oracle"}'
+    )


### PR DESCRIPTION
The vulnerability location does not currently support the new HarmonyOS asset.

In this PR, we add the necessary logic to persist and render HarmonyOS vulnerability locations across the schema and runtime flow, along with tests to validate the expected behavior.