### PR TITLE
feature: switch from semgrep to opengrep

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM python:3.11-alpine as base
+ENV OPENGREP_VERSION=v1.19.0
 FROM base as builder
 RUN apk add build-base
 RUN mkdir /install
@@ -9,7 +10,7 @@ RUN pip install --prefix=/install -r /requirement.txt
 FROM base
 RUN apk add libmagic bash curl
 RUN curl -fsSL https://raw.githubusercontent.com/opengrep/opengrep/main/install.sh -o /tmp/install-opengrep.sh \
-    && bash /tmp/install-opengrep.sh -v v1.19.0 \
+    && bash /tmp/install-opengrep.sh -v "${OPENGREP_VERSION}" \
     && rm /tmp/install-opengrep.sh
 COPY --from=builder /install /usr/local
 ENV PATH="/root/.opengrep/cli/latest:${PATH}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,9 +9,9 @@ RUN pip install --upgrade pip
 RUN pip install --prefix=/install -r /requirement.txt
 FROM base
 RUN apk add libmagic bash curl
-RUN curl -fsSL https://raw.githubusercontent.com/opengrep/opengrep/main/install.sh -o /tmp/install-opengrep.sh \
+RUN curl -fsSL https://raw.githubusercontent.com/opengrep/opengrep/${OPENGREP_VERSION}/install.sh -o /tmp/install-opengrep.sh \
     && bash /tmp/install-opengrep.sh -v "${OPENGREP_VERSION}" \
-    && rm /tmp/install-opengrep.sh
+    && rm -f /tmp/install-opengrep.sh
 COPY --from=builder /install /usr/local
 ENV PATH="/root/.opengrep/cli/latest:${PATH}"
 RUN mkdir -p /app/agent

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,20 @@
 FROM python:3.11-alpine as base
 FROM base as builder
 RUN apk add build-base
-RUN mkdir /install /semgrep_app
+RUN mkdir /install
 WORKDIR /install
 COPY requirement.txt /requirement.txt
 RUN pip install --upgrade pip
 RUN pip install --prefix=/install -r /requirement.txt
-RUN pip install --target=/semgrep_app semgrep==1.99.0
 FROM base
-RUN apk add libmagic
+RUN apk add libmagic bash curl
+RUN curl -fsSL https://raw.githubusercontent.com/opengrep/opengrep/main/install.sh -o /tmp/install-opengrep.sh \
+    && bash /tmp/install-opengrep.sh -v v1.19.0 \
+    && rm /tmp/install-opengrep.sh
 COPY --from=builder /install /usr/local
-COPY --from=builder /semgrep_app /opt/semgrep
-ENV PATH="/opt/semgrep/bin:${PATH}"
+ENV PATH="/root/.opengrep/cli/latest:${PATH}"
 RUN mkdir -p /app/agent
-ENV PYTHONPATH=/app:/opt/semgrep
+ENV PYTHONPATH=/app
 COPY agent /app/agent
 COPY ostorlab.yaml /app/agent/ostorlab.yaml
 WORKDIR /app

--- a/agent/semgrep_agent.py
+++ b/agent/semgrep_agent.py
@@ -49,7 +49,8 @@ def _run_analysis(
     input_file_path: str, max_memory_limit: int = DEFAULT_MEMORY_LIMIT
 ) -> tuple[bytes, bytes] | None:
     command = [
-        "semgrep",
+        "opengrep",
+        "scan",
         "-q",
         "--config",
         "auto",

--- a/tests/semgrep_agent_test.py
+++ b/tests/semgrep_agent_test.py
@@ -395,19 +395,20 @@ def testAgentSemgrep_whenValidMessage_constructCorrectCommand(
 
     test_agent.process(scan_message_file)
 
-    assert command_mock.call_args.args[0][0] == "semgrep"
-    assert command_mock.call_args.args[0][1] == "-q"
-    assert command_mock.call_args.args[0][2] == "--config"
-    assert command_mock.call_args.args[0][3] == "auto"
-    assert command_mock.call_args.args[0][4] == "--timeout"
-    assert command_mock.call_args.args[0][5] == "120"
-    assert command_mock.call_args.args[0][6] == "--timeout-threshold"
-    assert command_mock.call_args.args[0][7] == "0"
-    assert command_mock.call_args.args[0][8] == "--max-target-bytes"
-    assert command_mock.call_args.args[0][9] == "524288000"
-    assert command_mock.call_args.args[0][10] == "--max-memory"
-    assert command_mock.call_args.args[0][11] == "2147483648"
-    assert command_mock.call_args.args[0][12] == "--json"
+    assert command_mock.call_args.args[0][0] == "opengrep"
+    assert command_mock.call_args.args[0][1] == "scan"
+    assert command_mock.call_args.args[0][2] == "-q"
+    assert command_mock.call_args.args[0][3] == "--config"
+    assert command_mock.call_args.args[0][4] == "auto"
+    assert command_mock.call_args.args[0][5] == "--timeout"
+    assert command_mock.call_args.args[0][6] == "120"
+    assert command_mock.call_args.args[0][7] == "--timeout-threshold"
+    assert command_mock.call_args.args[0][8] == "0"
+    assert command_mock.call_args.args[0][9] == "--max-target-bytes"
+    assert command_mock.call_args.args[0][10] == "524288000"
+    assert command_mock.call_args.args[0][11] == "--max-memory"
+    assert command_mock.call_args.args[0][12] == "2147483648"
+    assert command_mock.call_args.args[0][13] == "--json"
 
 
 def testAgentSemgrep_whenIosAsset_addsIosAssetToVulnLocation(


### PR DESCRIPTION
in this pr :
updated the existing agent_semgrep implementation to run opengrep internally while keeping the public agent name/interface as semgrep
Instead of migrating all consumers from agent/ostorlab/semgrep to a new agent/ostorlab/opengrep key, this keeps the current agent contract stable and reduces the amount of required changes in RE, oxo

Changes:
Replaced the scanner command from semgrep to opengrep scan.
Updated the Docker image to install OpenGrep v1.19.0 using the official OpenGrep installer.
Removed the Semgrep-specific /opt/semgrep setup from the image.
Updated the command-construction unit test to expect opengrep scan.

testing opengrep and semgrep on vulnerable.java file (same findings)

<img width="865" height="1099" alt="image" src="https://github.com/user-attachments/assets/3e55f741-9659-469b-8ea6-b8c4d0ff2d10" />
