### PR TITLE
feature: Add support of repository asset in agent_semgrep

### DIFF
--- a/agent/semgrep_agent.py
+++ b/agent/semgrep_agent.py
@@ -159,7 +159,7 @@ class SemgrepAgent(agent.Agent, agent_report_vulnerability_mixin.AgentReportVuln
                 logger.error("Semgrep completed with errors %s", stderr)
 
     def _process_repository_asset(self, message: m.Message, memory_limit: int) -> None:
-        """Scan a repository mounted on the shared /code volume."""
+        """Scan a repository on the shared /code volume."""
         repository_url = message.data.get("repository_url")
         commit_hash = message.data.get("commit_hash")
         output = _run_analysis(REPOSITORY_CODE_PATH, memory_limit)

--- a/agent/semgrep_agent.py
+++ b/agent/semgrep_agent.py
@@ -162,9 +162,7 @@ class SemgrepAgent(agent.Agent, agent_report_vulnerability_mixin.AgentReportVuln
         """Scan a repository mounted on the shared /code volume."""
         repository_url = message.data.get("repository_url")
         commit_hash = message.data.get("commit_hash")
-        repository_path = REPOSITORY_CODE_PATH
-
-        output = _run_analysis(repository_path, memory_limit)
+        output = _run_analysis(REPOSITORY_CODE_PATH, memory_limit)
         if output is None:
             logger.error("Repository scan completed with errors.")
             return

--- a/agent/semgrep_agent.py
+++ b/agent/semgrep_agent.py
@@ -25,6 +25,7 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 COMMAND_TIMEOUT = 120
+REPOSITORY_COMMAND_TIMEOUT = 1200
 # Number of semgrep rules that can time out on a file before the file is skipped, 0 will have no limit.
 TIMEOUT_THRESHOLD = 0
 # 500MB
@@ -47,7 +48,9 @@ FILE_TYPE_WHITELIST = (
 
 
 def _run_analysis(
-    input_file_path: str, max_memory_limit: int = DEFAULT_MEMORY_LIMIT
+    input_file_path: str,
+    max_memory_limit: int = DEFAULT_MEMORY_LIMIT,
+    command_timeout: int = COMMAND_TIMEOUT,
 ) -> tuple[bytes, bytes] | None:
     command = [
         "opengrep",
@@ -56,7 +59,7 @@ def _run_analysis(
         "--config",
         "auto",
         "--timeout",
-        str(COMMAND_TIMEOUT),
+        str(command_timeout),
         "--timeout-threshold",
         str(TIMEOUT_THRESHOLD),
         "--max-target-bytes",
@@ -68,7 +71,7 @@ def _run_analysis(
     ]
     try:
         output = subprocess.run(
-            command, capture_output=True, check=True, timeout=COMMAND_TIMEOUT
+            command, capture_output=True, check=True, timeout=command_timeout
         )
     except subprocess.CalledProcessError as e:
         logger.error(
@@ -162,7 +165,11 @@ class SemgrepAgent(agent.Agent, agent_report_vulnerability_mixin.AgentReportVuln
         """Scan a repository on the shared /code volume."""
         repository_url = message.data.get("repository_url")
         commit_hash = message.data.get("commit_hash")
-        output = _run_analysis(REPOSITORY_CODE_PATH, memory_limit)
+        output = _run_analysis(
+            REPOSITORY_CODE_PATH,
+            memory_limit,
+            command_timeout=REPOSITORY_COMMAND_TIMEOUT,
+        )
         if output is None:
             logger.error("Repository scan completed with errors.")
             return

--- a/agent/semgrep_agent.py
+++ b/agent/semgrep_agent.py
@@ -31,6 +31,7 @@ TIMEOUT_THRESHOLD = 0
 FILE_SIZE_LIMIT = 500 * 1024 * 1024
 # 2GB
 DEFAULT_MEMORY_LIMIT = 2 * 1024 * 1024 * 1024
+REPOSITORY_CODE_PATH = "/code"
 
 FILE_TYPE_WHITELIST = (
     ".js",
@@ -91,11 +92,16 @@ class SemgrepAgent(agent.Agent, agent_report_vulnerability_mixin.AgentReportVuln
             message: A message containing the path and the content of the file to be processed
 
         """
-        content = utils.get_file_content(message)
-        path = message.data.get("path")
         memory_limit = (
             self.args.get("memory_limit", DEFAULT_MEMORY_LIMIT) or DEFAULT_MEMORY_LIMIT
         )
+
+        if message.selector == "v3.asset.repository":
+            self._process_repository_asset(message, memory_limit)
+            return
+
+        content = utils.get_file_content(message)
+        path = message.data.get("path")
 
         if content is None:
             logger.error("Received empty file.")
@@ -152,12 +158,38 @@ class SemgrepAgent(agent.Agent, agent_report_vulnerability_mixin.AgentReportVuln
             else:
                 logger.error("Semgrep completed with errors %s", stderr)
 
+    def _process_repository_asset(self, message: m.Message, memory_limit: int) -> None:
+        """Scan a repository mounted on the shared /code volume."""
+        repository_url = message.data.get("repository_url")
+        commit_hash = message.data.get("commit_hash")
+        repository_path = REPOSITORY_CODE_PATH
+
+        output = _run_analysis(repository_path, memory_limit)
+        if output is None:
+            logger.error("Repository scan completed with errors.")
+            return
+
+        stdout, stderr = output
+        if not isinstance(stdout, bytes) or len(stderr) > 0:
+            logger.error("Repository scan completed with errors %s", stderr)
+            return
+
+        json_output = json.loads(stdout)
+        self._emit_results(
+            json_output=json_output,
+            repository_url=repository_url,
+            commit_hash=commit_hash,
+        )
+        logger.debug("Repository scan completed without errors.")
+
     def _emit_results(
         self,
         json_output: dict[str, Any],
         package_name: str | None = None,
         bundle_id: str | None = None,
         harmony_bundle_name: str | None = None,
+        repository_url: str | None = None,
+        commit_hash: str | None = None,
     ) -> None:
         """Parses results and emits vulnerabilities."""
         for vuln in utils.parse_results(
@@ -165,6 +197,8 @@ class SemgrepAgent(agent.Agent, agent_report_vulnerability_mixin.AgentReportVuln
             package_name=package_name,
             bundle_id=bundle_id,
             harmony_bundle_name=harmony_bundle_name,
+            repository_url=repository_url,
+            commit_hash=commit_hash,
         ):
             logger.info("Found vulnerability: %s", vuln)
             self.report_vulnerability(

--- a/agent/utils.py
+++ b/agent/utils.py
@@ -22,6 +22,7 @@ from ostorlab.assets import asset as os_asset
 from ostorlab.assets import ios_store
 from ostorlab.assets import android_store
 from ostorlab.assets import harmonyos_store
+from ostorlab.assets import repository as repository_asset
 
 
 LINE_SIZE_MAX = 5000
@@ -151,9 +152,16 @@ def _prepare_vulnerability_location(
     package_name: str | None = None,
     bundle_id: str | None = None,
     harmony_bundle_name: str | None = None,
+    repository_url: str | None = None,
+    commit_hash: str | None = None,
 ) -> vulnerability_mixin.VulnerabilityLocation | None:
     """Prepare a `VulnerabilityLocation` with store asset and file path metadata."""
-    if bundle_id is None and package_name is None and harmony_bundle_name is None:
+    if (
+        bundle_id is None
+        and package_name is None
+        and harmony_bundle_name is None
+        and repository_url is None
+    ):
         return None
     asset: os_asset.Asset | None = None
     if bundle_id is not None:
@@ -162,6 +170,11 @@ def _prepare_vulnerability_location(
         asset = android_store.AndroidStore(package_name=package_name)
     if harmony_bundle_name is not None:
         asset = harmonyos_store.HarmonyOSStore(bundle_name=harmony_bundle_name)
+    if repository_url is not None:
+        asset = repository_asset.Repository(
+            repository_url=repository_url,
+            commit_hash=commit_hash or "",
+        )
 
     return vulnerability_mixin.VulnerabilityLocation(
         asset=asset,
@@ -179,6 +192,8 @@ def parse_results(
     package_name: str | None = None,
     bundle_id: str | None = None,
     harmony_bundle_name: str | None = None,
+    repository_url: str | None = None,
+    commit_hash: str | None = None,
 ) -> Iterator[Vulnerability]:
     """Parses JSON generated Semgrep results and yield vulnerability entries.
 
@@ -216,6 +231,8 @@ def parse_results(
                 package_name=package_name,
                 bundle_id=bundle_id,
                 harmony_bundle_name=harmony_bundle_name,
+                repository_url=repository_url,
+                commit_hash=commit_hash,
             )
         lines = vulnerability["extra"].get("lines", "").strip()[:LINE_SIZE_MAX]
 

--- a/ostorlab.yaml
+++ b/ostorlab.yaml
@@ -49,10 +49,15 @@ description: |
 license: Apache-2.0
 in_selectors: 
   - v3.asset.file
+  - v3.asset.repository
 out_selectors:
   - v3.report.vulnerability
 docker_file_path : Dockerfile 
 docker_build_root : .
+volumes:
+  - name: repository_code
+    path: /code
+    read_only: true
 args:
   - name: "memory_limit"
     description: "Memory limit for semgrep to use on a single file."

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -136,6 +136,17 @@ def scan_message_compressed_js_file() -> message.Message:
     return message.Message.from_data(selector, data=msg_data)
 
 
+@pytest.fixture
+def repository_asset_message() -> message.Message:
+    """Creates a dummy message of type v3.asset.repository for testing purposes."""
+    selector = "v3.asset.repository"
+    msg_data = {
+        "repository_url": "https://github.com/org/repo.git",
+        "commit_hash": "a1a10cdbc6551ba359169a3033f193b7f8c1b95d",
+    }
+    return message.Message.from_data(selector, data=msg_data)
+
+
 @pytest.fixture()
 def test_agent(
     agent_persist_mock: dict[str | bytes, str | bytes],

--- a/tests/semgrep_agent_test.py
+++ b/tests/semgrep_agent_test.py
@@ -481,3 +481,32 @@ def testAgentSemgrep_whenHarmonyOSAsset_addsHarmonyOSAssetToVulnLocation(
         '{"bundle_name": "a.b.c"}, "metadata": [{"type": "FILE_PATH", "value": "tests/files/vulnerable.java"}]}, '
         '"title": "Cbc Padding Oracle"}'
     )
+
+
+def testAgentSemgrep_whenRepositoryAsset_emitsBackVulnerabilityWithRepositoryLocation(
+    test_agent: semgrep_agent.SemgrepAgent,
+    agent_mock: list[message.Message],
+    agent_persist_mock: dict[str | bytes, str | bytes],
+    repository_asset_message: message.Message,
+    mocker: plugin.MockerFixture,
+) -> None:
+    """Ensure repository assets are scanned and emit repository vulnerability location."""
+    del agent_persist_mock
+    mocker.patch(
+        "agent.semgrep_agent._run_analysis",
+        return_value=(JSON_OUTPUT, EMPTY_ERROR_MESSAGE),
+    )
+
+    test_agent.process(repository_asset_message)
+    vuln = agent_mock[0].data
+
+    assert vuln["vulnerability_location"] is not None
+    assert vuln["vulnerability_location"]["repository"] == {
+        "repository_url": "https://github.com/org/repo.git",
+        "commit_hash": "a1a10cdbc6551ba359169a3033f193b7f8c1b95d",
+    }
+    assert vuln["vulnerability_location"]["metadata"][0]["type"] == "FILE_PATH"
+    assert (
+        vuln["vulnerability_location"]["metadata"][0]["value"]
+        == "/tmp/tmpza6g8qu0.java"
+    )


### PR DESCRIPTION
**Summary**

Add `v3.asset.repository` support to `agent_semgrep` so Semgrep can scan repository code mounted on the shared volume `code` and emit vulnerabilities with repository-aware location metadata.

**Why**

Repository assets contain identity metadata:
- `repository_url`
- `commit_hash`

They do not include file content.

To scan source code for this asset type, the agent now reads repository files from the shared per-scan volume and reports findings tied to the repository asset.

**What Changed**

**agent/semgrep_agent.py**

- Added repository flow in `process()` for `v3.asset.repository`
- Added `_process_repository_asset()` to run Semgrep on repository code
- Extended `_emit_results()` to pass repository context:
  - `repository_url`
  - `commit_hash`

**agent/utils.py**

Extended vulnerability-location builder to support repository assets.

Added repository fields to `parse_results()` so emitted vulnerability locations can include:
- `repository.repository_url`
- `repository.commit_hash`
- `metadata: FILE_PATH`

**ostorlab.yaml**

- Added `v3.asset.repository` to `in_selectors`
- Added shared volume mount:
  - `name: repository_code`
  - `path: /code`
  - `read_only: true`

**EDITS:**

- Add repository command timeout 

<img width="1574" height="1022" alt="image" src="https://github.com/user-attachments/assets/b325e456-c792-455b-a750-e22ad1a7d148" />
