### PR TITLE
feature: add provider support to vulnerability reporting

### DIFF
--- a/agent/semgrep_agent.py
+++ b/agent/semgrep_agent.py
@@ -165,6 +165,7 @@ class SemgrepAgent(agent.Agent, agent_report_vulnerability_mixin.AgentReportVuln
         """Scan a repository on the shared /code volume."""
         repository_url = message.data.get("repository_url")
         commit_hash = message.data.get("commit_hash")
+        provider = message.data.get("provider")
         output = _run_analysis(
             REPOSITORY_CODE_PATH,
             memory_limit,
@@ -184,6 +185,7 @@ class SemgrepAgent(agent.Agent, agent_report_vulnerability_mixin.AgentReportVuln
             json_output=json_output,
             repository_url=repository_url,
             commit_hash=commit_hash,
+            provider=provider,
         )
         logger.debug("Repository scan completed without errors.")
 
@@ -195,6 +197,7 @@ class SemgrepAgent(agent.Agent, agent_report_vulnerability_mixin.AgentReportVuln
         harmony_bundle_name: str | None = None,
         repository_url: str | None = None,
         commit_hash: str | None = None,
+        provider: str | None = None,
     ) -> None:
         """Parses results and emits vulnerabilities."""
         for vuln in utils.parse_results(
@@ -204,6 +207,7 @@ class SemgrepAgent(agent.Agent, agent_report_vulnerability_mixin.AgentReportVuln
             harmony_bundle_name=harmony_bundle_name,
             repository_url=repository_url,
             commit_hash=commit_hash,
+            provider=provider,
         ):
             logger.info("Found vulnerability: %s", vuln)
             self.report_vulnerability(

--- a/agent/utils.py
+++ b/agent/utils.py
@@ -154,6 +154,7 @@ def _prepare_vulnerability_location(
     harmony_bundle_name: str | None = None,
     repository_url: str | None = None,
     commit_hash: str | None = None,
+    provider: str | None = None,
 ) -> vulnerability_mixin.VulnerabilityLocation | None:
     """Prepare a `VulnerabilityLocation` with store asset and file path metadata."""
     if (
@@ -174,6 +175,7 @@ def _prepare_vulnerability_location(
         asset = repository_asset.Repository(
             repository_url=repository_url,
             commit_hash=commit_hash or "",
+            provider=provider or "",
         )
 
     return vulnerability_mixin.VulnerabilityLocation(
@@ -194,6 +196,7 @@ def parse_results(
     harmony_bundle_name: str | None = None,
     repository_url: str | None = None,
     commit_hash: str | None = None,
+    provider: str | None = None,
 ) -> Iterator[Vulnerability]:
     """Parses JSON generated Semgrep results and yield vulnerability entries.
 
@@ -233,6 +236,7 @@ def parse_results(
                 harmony_bundle_name=harmony_bundle_name,
                 repository_url=repository_url,
                 commit_hash=commit_hash,
+                provider=provider,
             )
         lines = vulnerability["extra"].get("lines", "").strip()[:LINE_SIZE_MAX]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -143,6 +143,7 @@ def repository_asset_message() -> message.Message:
     msg_data = {
         "repository_url": "https://github.com/org/repo.git",
         "commit_hash": "a1a10cdbc6551ba359169a3033f193b7f8c1b95d",
+        "provider": "GITHUB",
     }
     return message.Message.from_data(selector, data=msg_data)
 

--- a/tests/semgrep_agent_test.py
+++ b/tests/semgrep_agent_test.py
@@ -504,6 +504,7 @@ def testAgentSemgrep_whenRepositoryAsset_emitsBackVulnerabilityWithRepositoryLoc
     assert vuln["vulnerability_location"]["repository"] == {
         "repository_url": "https://github.com/org/repo.git",
         "commit_hash": "a1a10cdbc6551ba359169a3033f193b7f8c1b95d",
+        "provider": "GITHUB",
     }
     assert vuln["vulnerability_location"]["metadata"][0]["type"] == "FILE_PATH"
     assert (


### PR DESCRIPTION
## Title
Preserve repository provider in Semgrep findings

## Description
Thread the repository `provider` through Semgrep repository scans so emitted vulnerability locations include `provider` alongside `repository_url` and `commit_hash`.

Updates the repository scan test fixture and assertion to verify the provider is preserved in reported findings.