### PR TITLE
feature: exclude paths

### DIFF
--- a/agent/semgrep_agent.py
+++ b/agent/semgrep_agent.py
@@ -112,6 +112,9 @@ class SemgrepAgent(agent.Agent, agent_report_vulnerability_mixin.AgentReportVuln
         content = utils.get_file_content(message)
         path = message.data.get("path")
 
+        if utils.should_exclude_path(path, self.args.get("exclude_paths")) is True:
+            return
+
         if content is None:
             logger.error("Received empty file.")
             return

--- a/agent/semgrep_agent.py
+++ b/agent/semgrep_agent.py
@@ -109,11 +109,12 @@ class SemgrepAgent(agent.Agent, agent_report_vulnerability_mixin.AgentReportVuln
             self._process_repository_asset(message, memory_limit)
             return
 
-        content = utils.get_file_content(message)
         path = message.data.get("path")
 
         if utils.should_exclude_path(path, self.args.get("exclude_paths")) is True:
             return
+
+        content = utils.get_file_content(message)
 
         if content is None:
             logger.error("Received empty file.")

--- a/agent/semgrep_agent.py
+++ b/agent/semgrep_agent.py
@@ -111,7 +111,10 @@ class SemgrepAgent(agent.Agent, agent_report_vulnerability_mixin.AgentReportVuln
 
         path = message.data.get("path")
 
-        if utils.should_exclude_path(path, self.args.get("exclude_paths")) is True:
+        if (
+            utils.should_exclude_path(path, self.args.get("exclude_path_regexes"))
+            is True
+        ):
             return
 
         content = utils.get_file_content(message)

--- a/agent/utils.py
+++ b/agent/utils.py
@@ -40,6 +40,28 @@ RISK_RATING_MAPPING = {
 logger = logging.getLogger(__name__)
 
 
+def should_exclude_path(path: str | None, exclude_paths: list[str] | None) -> bool:
+    """Report whether a file path starts with one of the excluded prefixes.
+
+    Args:
+        path: The file path reported in the message, or None.
+        exclude_paths: List of path prefixes to match against the path.
+
+    Returns:
+        True if the path starts with at least one prefix and should be skipped,
+        False otherwise.
+    """
+    if path is None or exclude_paths is None or len(exclude_paths) == 0:
+        return False
+    for prefix in exclude_paths:
+        if path.startswith(prefix) is True:
+            logger.info(
+                "Skipping file %s: path matches exclude prefix %r.", path, prefix
+            )
+            return True
+    return False
+
+
 @dataclasses.dataclass
 class Vulnerability:
     """Vulnerability dataclass to pass to the emit method."""

--- a/agent/utils.py
+++ b/agent/utils.py
@@ -41,22 +41,27 @@ logger = logging.getLogger(__name__)
 
 
 def should_exclude_path(path: str | None, exclude_paths: list[str] | None) -> bool:
-    """Report whether a file path starts with one of the excluded prefixes.
+    """Report whether a file path matches one of the exclusion regex patterns.
 
     Args:
         path: The file path reported in the message, or None.
-        exclude_paths: List of path prefixes to match against the path.
+        exclude_paths: List of regex patterns to match against the path.
 
     Returns:
-        True if the path starts with at least one prefix and should be skipped,
+        True if the path matches at least one pattern and should be skipped,
         False otherwise.
     """
     if path is None or exclude_paths is None or len(exclude_paths) == 0:
         return False
-    for prefix in exclude_paths:
-        if path.startswith(prefix) is True:
+    for pattern in exclude_paths:
+        try:
+            matched = re.search(pattern, path)
+        except re.error as e:
+            logger.warning("Invalid exclude_paths regex %r: %s", pattern, e)
+            continue
+        if matched is not None:
             logger.info(
-                "Skipping file %s: path matches exclude prefix %r.", path, prefix
+                "Skipping file %s: path matches exclude pattern %r.", path, pattern
             )
             return True
     return False

--- a/agent/utils.py
+++ b/agent/utils.py
@@ -40,24 +40,26 @@ RISK_RATING_MAPPING = {
 logger = logging.getLogger(__name__)
 
 
-def should_exclude_path(path: str | None, exclude_paths: list[str] | None) -> bool:
+def should_exclude_path(
+    path: str | None, exclude_path_regexes: list[str] | None
+) -> bool:
     """Report whether a file path matches one of the exclusion regex patterns.
 
     Args:
         path: The file path reported in the message, or None.
-        exclude_paths: List of regex patterns to match against the path.
+        exclude_path_regexes: List of regex patterns to match against the path.
 
     Returns:
         True if the path matches at least one pattern and should be skipped,
         False otherwise.
     """
-    if path is None or exclude_paths is None or len(exclude_paths) == 0:
+    if path is None or exclude_path_regexes is None or len(exclude_path_regexes) == 0:
         return False
-    for pattern in exclude_paths:
+    for pattern in exclude_path_regexes:
         try:
             matched = re.search(pattern, path)
         except re.error as e:
-            logger.warning("Invalid exclude_paths regex %r: %s", pattern, e)
+            logger.warning("Invalid exclude_path_regexes regex %r: %s", pattern, e)
             continue
         if matched is not None:
             logger.info(

--- a/ostorlab.yaml
+++ b/ostorlab.yaml
@@ -63,6 +63,6 @@ args:
   - name: "memory_limit"
     description: "Memory limit for semgrep to use on a single file."
     type: "number"
-  - name: "exclude_paths"
+  - name: "exclude_path_regexes"
     type: "array"
     description: "List of regex patterns; files whose path matches any pattern are skipped."

--- a/ostorlab.yaml
+++ b/ostorlab.yaml
@@ -63,3 +63,6 @@ args:
   - name: "memory_limit"
     description: "Memory limit for semgrep to use on a single file."
     type: "number"
+  - name: "exclude_paths"
+    type: "array"
+    description: "List of regex patterns; files whose path matches any pattern are skipped."

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -185,6 +185,30 @@ def test_agent(
 
 
 @pytest.fixture()
+def test_agent_with_exclude_paths(
+    agent_persist_mock: dict[str | bytes, str | bytes],
+) -> semgrep_agent.SemgrepAgent:
+    """Semgrep agent configured to exclude files under /workspace."""
+    with (pathlib.Path(__file__).parent.parent / "ostorlab.yaml").open() as yaml_o:
+        definition = agent_definitions.AgentDefinition.from_yaml(yaml_o)
+        settings = runtime_definitions.AgentSettings(
+            key="agent/ostorlab/semgrep",
+            bus_url="NA",
+            bus_exchange_topic="NA",
+            args=[
+                {
+                    "name": "exclude_paths",
+                    "type": "array",
+                    "value": [r"^/workspace(/|$)"],
+                }
+            ],
+            healthcheck_port=random.randint(5000, 6000),
+            redis_url="redis://guest:guest@localhost:6379",
+        )
+        return semgrep_agent.SemgrepAgent(definition, settings)
+
+
+@pytest.fixture()
 def vulnerabilities() -> list[dict[str, Any]]:
     vulnz = cast(list[dict[str, Any]], JSON_OUTPUT.get("results"))
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -187,7 +187,7 @@ def test_agent(
 
 
 @pytest.fixture()
-def test_agent_with_exclude_paths(
+def test_agent_with_exclude_path_regexes(
     agent_persist_mock: dict[str | bytes, str | bytes],
 ) -> semgrep_agent.SemgrepAgent:
     """Semgrep agent configured to exclude files under /workspace."""
@@ -199,7 +199,7 @@ def test_agent_with_exclude_paths(
             bus_exchange_topic="NA",
             args=[
                 utils_definitions.Arg(
-                    name="exclude_paths",
+                    name="exclude_path_regexes",
                     type="array",
                     value=json.dumps([r"^/workspace(/|$)"]).encode(),
                 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -198,10 +198,10 @@ def test_agent_with_exclude_paths(
             bus_url="NA",
             bus_exchange_topic="NA",
             args=[
-                utils_definitions.Arg.build(
+                utils_definitions.Arg(
                     name="exclude_paths",
                     type="array",
-                    value=json.dumps([r"^/workspace(/|$)"]),
+                    value=json.dumps([r"^/workspace(/|$)"]).encode(),
                 )
             ],
             healthcheck_port=random.randint(5000, 6000),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 """conftest for semgrep agent tests"""
 
+import json
 import random
 import pathlib
 from typing import Any, cast
@@ -8,6 +9,7 @@ import pytest
 from ostorlab.agent.message import message
 from ostorlab.agent import definitions as agent_definitions
 from ostorlab.runtimes import definitions as runtime_definitions
+from ostorlab.utils import definitions as utils_definitions
 
 from agent import semgrep_agent
 
@@ -196,11 +198,11 @@ def test_agent_with_exclude_paths(
             bus_url="NA",
             bus_exchange_topic="NA",
             args=[
-                {
-                    "name": "exclude_paths",
-                    "type": "array",
-                    "value": [r"^/workspace(/|$)"],
-                }
+                utils_definitions.Arg.build(
+                    name="exclude_paths",
+                    type="array",
+                    value=json.dumps([r"^/workspace(/|$)"]),
+                )
             ],
             healthcheck_port=random.randint(5000, 6000),
             redis_url="redis://guest:guest@localhost:6379",

--- a/tests/semgrep_agent_test.py
+++ b/tests/semgrep_agent_test.py
@@ -612,3 +612,23 @@ def testAgentSemgrep_whenRepositoryArchiveAsset_scansSharedCodeVolume(
     test_agent.process(repository_archive_asset_message)
 
     assert run_analysis_mock.call_args.args[0] == semgrep_agent.REPOSITORY_CODE_PATH
+
+
+def testAgentSemgrep_whenFilePathIsExcluded_notProcessMessage(
+    test_agent_with_exclude_paths: semgrep_agent.SemgrepAgent,
+    agent_mock: list[message.Message],
+    agent_persist_mock: dict[str | bytes, str | bytes],
+    mocker: plugin.MockerFixture,
+) -> None:
+    """A file whose path matches an exclude pattern is skipped: no scan, no emitted message."""
+    del agent_persist_mock
+    run_analysis_mock = mocker.patch("agent.semgrep_agent._run_analysis")
+    file_message = message.Message.from_data(
+        selector="v3.asset.file",
+        data={"content": b"public class A {}", "path": "/workspace/src/A.java"},
+    )
+
+    test_agent_with_exclude_paths.process(file_message)
+
+    assert run_analysis_mock.call_count == 0
+    assert len(agent_mock) == 0

--- a/tests/semgrep_agent_test.py
+++ b/tests/semgrep_agent_test.py
@@ -620,9 +620,10 @@ def testAgentSemgrep_whenFilePathIsExcluded_notProcessMessage(
     agent_persist_mock: dict[str | bytes, str | bytes],
     mocker: plugin.MockerFixture,
 ) -> None:
-    """A file whose path matches an exclude pattern is skipped: no scan, no emitted message."""
+    """A file whose path matches an exclude pattern is skipped before any content fetch or scan."""
     del agent_persist_mock
     run_analysis_mock = mocker.patch("agent.semgrep_agent._run_analysis")
+    get_content_mock = mocker.patch("agent.semgrep_agent.utils.get_file_content")
     file_message = message.Message.from_data(
         selector="v3.asset.file",
         data={"content": b"public class A {}", "path": "/workspace/src/A.java"},
@@ -630,5 +631,6 @@ def testAgentSemgrep_whenFilePathIsExcluded_notProcessMessage(
 
     test_agent_with_exclude_paths.process(file_message)
 
+    assert get_content_mock.call_count == 0
     assert run_analysis_mock.call_count == 0
     assert len(agent_mock) == 0

--- a/tests/semgrep_agent_test.py
+++ b/tests/semgrep_agent_test.py
@@ -615,7 +615,7 @@ def testAgentSemgrep_whenRepositoryArchiveAsset_scansSharedCodeVolume(
 
 
 def testAgentSemgrep_whenFilePathIsExcluded_notProcessMessage(
-    test_agent_with_exclude_paths: semgrep_agent.SemgrepAgent,
+    test_agent_with_exclude_path_regexes: semgrep_agent.SemgrepAgent,
     agent_mock: list[message.Message],
     agent_persist_mock: dict[str | bytes, str | bytes],
     mocker: plugin.MockerFixture,
@@ -629,7 +629,7 @@ def testAgentSemgrep_whenFilePathIsExcluded_notProcessMessage(
         data={"content": b"public class A {}", "path": "/workspace/src/A.java"},
     )
 
-    test_agent_with_exclude_paths.process(file_message)
+    test_agent_with_exclude_path_regexes.process(file_message)
 
     assert get_content_mock.call_count == 0
     assert run_analysis_mock.call_count == 0

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -209,3 +209,33 @@ def testGetFileContent_whenNoContentIsAvailable_shouldReturnNone() -> None:
     content = utils.get_file_content(message)
 
     assert content is None
+
+
+def testShouldExcludePath_whenPathStartsWithWorkspacePrefix_shouldReturnTrue() -> None:
+    result = utils.should_exclude_path("/workspace/src/main.py", ["/workspace"])
+
+    assert result is True
+
+
+def testShouldExcludePath_whenPathDoesNotStartWithPrefix_shouldReturnFalse() -> None:
+    result = utils.should_exclude_path("/tmp/main.py", ["/workspace"])
+
+    assert result is False
+
+
+def testShouldExcludePath_whenPathIsNone_shouldReturnFalse() -> None:
+    result = utils.should_exclude_path(None, ["/workspace"])
+
+    assert result is False
+
+
+def testShouldExcludePath_whenExcludePathsIsEmpty_shouldReturnFalse() -> None:
+    result = utils.should_exclude_path("/workspace/a.py", [])
+
+    assert result is False
+
+
+def testShouldExcludePath_whenExcludePathsIsNone_shouldReturnFalse() -> None:
+    result = utils.should_exclude_path("/workspace/a.py", None)
+
+    assert result is False

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -211,20 +211,26 @@ def testGetFileContent_whenNoContentIsAvailable_shouldReturnNone() -> None:
     assert content is None
 
 
-def testShouldExcludePath_whenPathStartsWithWorkspacePrefix_shouldReturnTrue() -> None:
-    result = utils.should_exclude_path("/workspace/src/main.py", ["/workspace"])
+def testShouldExcludePath_whenPathMatchesWorkspacePattern_shouldReturnTrue() -> None:
+    result = utils.should_exclude_path("/workspace/src/main.py", [r"^/workspace(/|$)"])
 
     assert result is True
 
 
-def testShouldExcludePath_whenPathDoesNotStartWithPrefix_shouldReturnFalse() -> None:
-    result = utils.should_exclude_path("/tmp/main.py", ["/workspace"])
+def testShouldExcludePath_whenPathDoesNotMatch_shouldReturnFalse() -> None:
+    result = utils.should_exclude_path("/tmp/main.py", [r"^/workspace(/|$)"])
+
+    assert result is False
+
+
+def testShouldExcludePath_whenSimilarPrefixNotUnderWorkspace_shouldReturnFalse() -> None:
+    result = utils.should_exclude_path("/workspace_backup/a.py", [r"^/workspace(/|$)"])
 
     assert result is False
 
 
 def testShouldExcludePath_whenPathIsNone_shouldReturnFalse() -> None:
-    result = utils.should_exclude_path(None, ["/workspace"])
+    result = utils.should_exclude_path(None, [r"^/workspace(/|$)"])
 
     assert result is False
 
@@ -237,5 +243,11 @@ def testShouldExcludePath_whenExcludePathsIsEmpty_shouldReturnFalse() -> None:
 
 def testShouldExcludePath_whenExcludePathsIsNone_shouldReturnFalse() -> None:
     result = utils.should_exclude_path("/workspace/a.py", None)
+
+    assert result is False
+
+
+def testShouldExcludePath_whenRegexIsInvalid_shouldSkipPatternAndReturnFalse() -> None:
+    result = utils.should_exclude_path("/workspace/a.py", ["[invalid("])
 
     assert result is False

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -223,7 +223,9 @@ def testShouldExcludePath_whenPathDoesNotMatch_shouldReturnFalse() -> None:
     assert result is False
 
 
-def testShouldExcludePath_whenSimilarPrefixNotUnderWorkspace_shouldReturnFalse() -> None:
+def testShouldExcludePath_whenSimilarPrefixNotUnderWorkspace_shouldReturnFalse() -> (
+    None
+):
     result = utils.should_exclude_path("/workspace_backup/a.py", [r"^/workspace(/|$)"])
 
     assert result is False


### PR DESCRIPTION
# Add exclude_path_regexes arg to skip files by regex pattern

Adds a new `exclude_path_regexes` arg (list of regex patterns). When a `v3.asset.file` message has a path that matches one of the patterns, the agent logs and skips the file instead of scanning it.

- New `exclude_path_regexes` arg in `ostorlab.yaml`.
- File processing skips any path matching an excluded pattern.
