### PR TITLE
feature: Support multi-asset repository scan paths in Semgrep agent

### DIFF
--- a/agent/semgrep_agent.py
+++ b/agent/semgrep_agent.py
@@ -3,6 +3,7 @@
 import json
 import logging
 import os
+import re
 import subprocess
 import tempfile
 from typing import Any
@@ -34,6 +35,7 @@ FILE_SIZE_LIMIT = 500 * 1024 * 1024
 # 2GB
 DEFAULT_MEMORY_LIMIT = 2 * 1024 * 1024 * 1024
 ASSETS_CODE_PATH = "/code"
+ASSET_DIRECTORY_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
 REPOSITORY_SELECTOR = "v3.asset.repository"
 REPOSITORY_ARCHIVE_SELECTOR = "v3.asset.file.repository_archive"
 
@@ -181,6 +183,13 @@ class SemgrepAgent(agent.Agent, agent_report_vulnerability_mixin.AgentReportVuln
         """Scan source code extracted to the shared /code volume."""
         repository_code_path: str = ASSETS_CODE_PATH
         if asset_directory is not None and len(asset_directory) > 0:
+            if ASSET_DIRECTORY_PATTERN.fullmatch(asset_directory) is None:
+                logger.error(
+                    "Refusing to scan invalid repository asset directory `%s`.",
+                    asset_directory,
+                )
+                return None
+
             repository_code_path = os.path.realpath(
                 os.path.join(ASSETS_CODE_PATH, asset_directory)
             )

--- a/agent/semgrep_agent.py
+++ b/agent/semgrep_agent.py
@@ -181,7 +181,19 @@ class SemgrepAgent(agent.Agent, agent_report_vulnerability_mixin.AgentReportVuln
         """Scan source code extracted to the shared /code volume."""
         repository_code_path: str = ASSETS_CODE_PATH
         if asset_directory is not None and len(asset_directory) > 0:
-            repository_code_path = os.path.join(ASSETS_CODE_PATH, asset_directory)
+            repository_code_path = os.path.realpath(
+                os.path.join(ASSETS_CODE_PATH, asset_directory)
+            )
+            assets_code_path = os.path.realpath(ASSETS_CODE_PATH)
+            if os.path.commonpath([assets_code_path, repository_code_path]) != (
+                assets_code_path
+            ):
+                logger.error(
+                    "Refusing to scan repository asset directory outside `%s`: `%s`.",
+                    ASSETS_CODE_PATH,
+                    asset_directory,
+                )
+                return None
 
         output = _run_analysis(
             repository_code_path,
@@ -210,6 +222,11 @@ class SemgrepAgent(agent.Agent, agent_report_vulnerability_mixin.AgentReportVuln
             asset_directory = utils.build_repository_asset_directory(
                 repository_url, commit_hash
             )
+        else:
+            logger.warning(
+                "Repository asset is missing repository_url or commit_hash; falling back to `%s`.",
+                ASSETS_CODE_PATH,
+            )
 
         json_output = self._scan_repository_code(memory_limit, asset_directory)
         if json_output is None:
@@ -231,6 +248,11 @@ class SemgrepAgent(agent.Agent, agent_report_vulnerability_mixin.AgentReportVuln
         if content_url is not None:
             asset_directory = utils.build_repository_archive_asset_directory(
                 content_url
+            )
+        else:
+            logger.warning(
+                "Repository archive asset is missing content_url; falling back to `%s`.",
+                ASSETS_CODE_PATH,
             )
 
         json_output = self._scan_repository_code(memory_limit, asset_directory)

--- a/agent/semgrep_agent.py
+++ b/agent/semgrep_agent.py
@@ -16,7 +16,6 @@ from rich import logging as rich_logging
 
 from agent import utils
 
-
 logging.basicConfig(
     format="%(message)s",
     datefmt="[%X]",

--- a/agent/semgrep_agent.py
+++ b/agent/semgrep_agent.py
@@ -2,6 +2,7 @@
 
 import json
 import logging
+import os
 import subprocess
 import tempfile
 from typing import Any
@@ -32,7 +33,7 @@ TIMEOUT_THRESHOLD = 0
 FILE_SIZE_LIMIT = 500 * 1024 * 1024
 # 2GB
 DEFAULT_MEMORY_LIMIT = 2 * 1024 * 1024 * 1024
-REPOSITORY_CODE_PATH = "/code"
+ASSETS_CODE_PATH = "/code"
 REPOSITORY_SELECTOR = "v3.asset.repository"
 REPOSITORY_ARCHIVE_SELECTOR = "v3.asset.file.repository_archive"
 
@@ -174,10 +175,16 @@ class SemgrepAgent(agent.Agent, agent_report_vulnerability_mixin.AgentReportVuln
             else:
                 logger.error("Semgrep completed with errors %s", stderr)
 
-    def _scan_repository_code(self, memory_limit: int) -> dict[str, Any] | None:
-        """Scan the source code extracted to the shared /code volume, the content carried by the message is never read."""
+    def _scan_repository_code(
+        self, memory_limit: int, asset_directory: str | None = None
+    ) -> dict[str, Any] | None:
+        """Scan source code extracted to the shared /code volume."""
+        repository_code_path: str = ASSETS_CODE_PATH
+        if asset_directory is not None and len(asset_directory) > 0:
+            repository_code_path = os.path.join(ASSETS_CODE_PATH, asset_directory)
+
         output = _run_analysis(
-            REPOSITORY_CODE_PATH,
+            repository_code_path,
             memory_limit,
             command_timeout=REPOSITORY_COMMAND_TIMEOUT,
         )
@@ -196,14 +203,22 @@ class SemgrepAgent(agent.Agent, agent_report_vulnerability_mixin.AgentReportVuln
 
     def _process_repository_asset(self, message: m.Message, memory_limit: int) -> None:
         """Scan a repository asset and report against its repository URL."""
-        json_output = self._scan_repository_code(memory_limit)
+        repository_url: str | None = message.data.get("repository_url")
+        commit_hash: str | None = message.data.get("commit_hash")
+        asset_directory: str | None = None
+        if repository_url is not None and commit_hash is not None:
+            asset_directory = utils.build_repository_asset_directory(
+                repository_url, commit_hash
+            )
+
+        json_output = self._scan_repository_code(memory_limit, asset_directory)
         if json_output is None:
             return
 
         self._emit_results(
             json_output=json_output,
-            repository_url=message.data.get("repository_url"),
-            commit_hash=message.data.get("commit_hash"),
+            repository_url=repository_url,
+            commit_hash=commit_hash,
             provider=message.data.get("provider"),
         )
 
@@ -211,13 +226,20 @@ class SemgrepAgent(agent.Agent, agent_report_vulnerability_mixin.AgentReportVuln
         self, message: m.Message, memory_limit: int
     ) -> None:
         """Scan a repository archive asset and report against its content URL, it carries no repository URL, commit hash nor provider."""
-        json_output = self._scan_repository_code(memory_limit)
+        content_url: str | None = message.data.get("content_url")
+        asset_directory: str | None = None
+        if content_url is not None:
+            asset_directory = utils.build_repository_archive_asset_directory(
+                content_url
+            )
+
+        json_output = self._scan_repository_code(memory_limit, asset_directory)
         if json_output is None:
             return
 
         self._emit_results(
             json_output=json_output,
-            archive_content_url=message.data.get("content_url"),
+            archive_content_url=content_url,
         )
 
     def _emit_results(

--- a/agent/semgrep_agent.py
+++ b/agent/semgrep_agent.py
@@ -226,13 +226,19 @@ class SemgrepAgent(agent.Agent, agent_report_vulnerability_mixin.AgentReportVuln
         repository_url: str | None = message.data.get("repository_url")
         commit_hash: str | None = message.data.get("commit_hash")
         asset_directory: str | None = None
-        if repository_url is not None and commit_hash is not None:
-            asset_directory = utils.build_repository_asset_directory(
+        if (
+            repository_url is not None
+            and repository_url != ""
+            and commit_hash is not None
+            and commit_hash != ""
+        ):
+            asset_directory = utils.construct_repository_asset_directory_name(
                 repository_url, commit_hash
             )
         else:
             logger.warning(
-                "Repository asset is missing repository_url or commit_hash; falling back to `%s`.",
+                "Repository asset is missing repository_url or commit_hash; "
+                "falling back to `%s`.",
                 ASSETS_CODE_PATH,
             )
 
@@ -253,8 +259,8 @@ class SemgrepAgent(agent.Agent, agent_report_vulnerability_mixin.AgentReportVuln
         """Scan a repository archive asset and report against its content URL, it carries no repository URL, commit hash nor provider."""
         content_url: str | None = message.data.get("content_url")
         asset_directory: str | None = None
-        if content_url is not None:
-            asset_directory = utils.build_repository_archive_asset_directory(
+        if content_url is not None and content_url != "":
+            asset_directory = utils.construct_repository_archive_asset_directory_name(
                 content_url
             )
         else:

--- a/agent/semgrep_agent.py
+++ b/agent/semgrep_agent.py
@@ -223,15 +223,10 @@ class SemgrepAgent(agent.Agent, agent_report_vulnerability_mixin.AgentReportVuln
 
     def _process_repository_asset(self, message: m.Message, memory_limit: int) -> None:
         """Scan a repository asset and report against its repository URL."""
-        repository_url: str | None = message.data.get("repository_url")
-        commit_hash: str | None = message.data.get("commit_hash")
+        repository_url: str | None = message.data.get("repository_url") or None
+        commit_hash: str | None = message.data.get("commit_hash") or None
         asset_directory: str | None = None
-        if (
-            repository_url is not None
-            and repository_url != ""
-            and commit_hash is not None
-            and commit_hash != ""
-        ):
+        if repository_url is not None and commit_hash is not None:
             asset_directory = utils.construct_repository_asset_directory_name(
                 repository_url, commit_hash
             )
@@ -257,9 +252,9 @@ class SemgrepAgent(agent.Agent, agent_report_vulnerability_mixin.AgentReportVuln
         self, message: m.Message, memory_limit: int
     ) -> None:
         """Scan a repository archive asset and report against its content URL, it carries no repository URL, commit hash nor provider."""
-        content_url: str | None = message.data.get("content_url")
+        content_url: str | None = message.data.get("content_url") or None
         asset_directory: str | None = None
-        if content_url is not None and content_url != "":
+        if content_url is not None:
             asset_directory = utils.construct_repository_archive_asset_directory_name(
                 content_url
             )

--- a/agent/semgrep_agent.py
+++ b/agent/semgrep_agent.py
@@ -177,31 +177,39 @@ class SemgrepAgent(agent.Agent, agent_report_vulnerability_mixin.AgentReportVuln
                 logger.error("Semgrep completed with errors %s", stderr)
 
     def _scan_repository_code(
-        self, memory_limit: int, asset_directory: str | None = None
+        self, memory_limit: int, asset_directory: str
     ) -> dict[str, Any] | None:
-        """Scan source code extracted to the shared /code volume."""
-        repository_code_path: str = ASSETS_CODE_PATH
-        if asset_directory is not None and len(asset_directory) > 0:
-            if ASSET_DIRECTORY_PATTERN.fullmatch(asset_directory) is None:
-                logger.error(
-                    "Refusing to scan invalid repository asset directory `%s`.",
-                    asset_directory,
-                )
-                return None
+        """Scan source code extracted under the shared /code volume.
 
-            repository_code_path = os.path.realpath(
-                os.path.join(ASSETS_CODE_PATH, asset_directory)
+        Args:
+            memory_limit: Maximum memory the Semgrep process may use.
+            asset_directory: Single path component naming the extracted asset
+                directory under `/code`. It is validated against a safe-name
+                pattern and a containment check as defense in depth before any
+                scan runs, so a malformed or traversal-style value can never
+                escape `/code` or scan the wrong target.
+        """
+        if ASSET_DIRECTORY_PATTERN.fullmatch(asset_directory) is None:
+            logger.error(
+                "Refusing to scan invalid repository asset directory `%s`.",
+                asset_directory,
             )
-            assets_code_path = os.path.realpath(ASSETS_CODE_PATH)
-            if os.path.commonpath([assets_code_path, repository_code_path]) != (
-                assets_code_path
-            ):
-                logger.error(
-                    "Refusing to scan repository asset directory outside `%s`: `%s`.",
-                    ASSETS_CODE_PATH,
-                    asset_directory,
-                )
-                return None
+            return None
+
+        repository_code_path: str = os.path.realpath(
+            os.path.join(ASSETS_CODE_PATH, asset_directory)
+        )
+        assets_code_path: str = os.path.realpath(ASSETS_CODE_PATH)
+        if (
+            os.path.commonpath([assets_code_path, repository_code_path])
+            != assets_code_path
+        ):
+            logger.error(
+                "Refusing to scan repository asset directory outside `%s`: `%s`.",
+                ASSETS_CODE_PATH,
+                asset_directory,
+            )
+            return None
 
         output = _run_analysis(
             repository_code_path,
@@ -222,21 +230,31 @@ class SemgrepAgent(agent.Agent, agent_report_vulnerability_mixin.AgentReportVuln
         return json_output
 
     def _process_repository_asset(self, message: m.Message, memory_limit: int) -> None:
-        """Scan a repository asset and report against its repository URL."""
-        repository_url: str | None = message.data.get("repository_url") or None
-        commit_hash: str | None = message.data.get("commit_hash") or None
-        asset_directory: str | None = None
-        if repository_url is not None and commit_hash is not None:
-            asset_directory = utils.construct_repository_asset_directory_name(
-                repository_url, commit_hash
-            )
-        else:
-            logger.warning(
-                "Repository asset is missing repository_url or commit_hash; "
-                "falling back to `%s`.",
-                ASSETS_CODE_PATH,
-            )
+        """Scan a repository asset and report against its repository URL.
 
+        A repository asset that is missing its `repository_url` or `commit_hash`
+        (either `None` or an empty string) cannot identify its extracted
+        directory, so the scan is refused outright rather than falling back to
+        the shared `/code` root, which could attribute findings to the wrong
+        asset.
+        """
+        repository_url: str | None = message.data.get("repository_url")
+        commit_hash: str | None = message.data.get("commit_hash")
+        if (
+            repository_url is None
+            or repository_url == ""
+            or commit_hash is None
+            or commit_hash == ""
+        ):
+            logger.error(
+                "Repository asset is missing repository_url or commit_hash; "
+                "refusing to scan."
+            )
+            return
+
+        asset_directory: str = utils.construct_repository_asset_directory_name(
+            repository_url, commit_hash
+        )
         json_output = self._scan_repository_code(memory_limit, asset_directory)
         if json_output is None:
             return
@@ -251,18 +269,27 @@ class SemgrepAgent(agent.Agent, agent_report_vulnerability_mixin.AgentReportVuln
     def _process_repository_archive_asset(
         self, message: m.Message, memory_limit: int
     ) -> None:
-        """Scan a repository archive asset and report against its content URL, it carries no repository URL, commit hash nor provider."""
-        content_url: str | None = message.data.get("content_url") or None
-        asset_directory: str | None = None
-        if content_url is not None:
-            asset_directory = utils.construct_repository_archive_asset_directory_name(
-                content_url
+        """Scan a repository archive asset and report against its content URL.
+
+        A repository archive asset is identified by its uploaded `content_url`,
+        which must follow the `.../uploads/<uuid>` GCS shape. A missing or
+        malformed `content_url` is rejected outright rather than falling back to
+        the shared `/code` root, which could scan the wrong target.
+        """
+        content_url: str | None = message.data.get("content_url")
+        if content_url is None or content_url == "":
+            logger.error(
+                "Repository archive asset is missing content_url; refusing to scan."
             )
-        else:
-            logger.warning(
-                "Repository archive asset is missing content_url; falling back to `%s`.",
-                ASSETS_CODE_PATH,
+            return
+
+        try:
+            asset_directory: str = (
+                utils.construct_repository_archive_asset_directory_name(content_url)
             )
+        except ValueError as e:
+            logger.error("Invalid repository archive content_url: %s", e)
+            return
 
         json_output = self._scan_repository_code(memory_limit, asset_directory)
         if json_output is None:

--- a/agent/utils.py
+++ b/agent/utils.py
@@ -40,6 +40,40 @@ RISK_RATING_MAPPING = {
 logger = logging.getLogger(__name__)
 
 
+def build_repository_asset_directory(repository_url: str, commit_hash: str) -> str:
+    """Build the repository extraction folder name used in multi-asset scans.
+
+    Args:
+        repository_url: URL of the repository asset.
+        commit_hash: Commit hash checked out for the repository asset.
+
+    Returns:
+        Folder name composed from the repository name and commit hash.
+    """
+    parsed_url: parse.ParseResult = parse.urlparse(repository_url)
+    repository_path: str = parsed_url.path
+    if len(repository_path) == 0:
+        repository_path = repository_url
+
+    repository_name: str = os.path.basename(repository_path.rstrip("/"))
+    if repository_name.endswith(".git") is True:
+        repository_name = repository_name[: -len(".git")]
+    return f"{repository_name}_{commit_hash}"
+
+
+def build_repository_archive_asset_directory(content_url: str) -> str:
+    """Build the archive extraction folder name from its uploaded content URL.
+
+    Args:
+        content_url: URL of the uploaded repository archive.
+
+    Returns:
+        Last path segment of the archive content URL.
+    """
+    parsed_url: parse.ParseResult = parse.urlparse(content_url)
+    return os.path.basename(parsed_url.path.rstrip("/"))
+
+
 def should_exclude_path(
     path: str | None, exclude_path_regexes: list[str] | None
 ) -> bool:

--- a/agent/utils.py
+++ b/agent/utils.py
@@ -1,30 +1,27 @@
 """Utilities for Semgrep Agent"""
 
 import dataclasses
-import mimetypes
-import requests
+import json
 import logging
+import mimetypes
 import os
 import re
-from typing import Any, Iterator
+from collections.abc import Iterator
+from typing import Any
 from urllib import parse
-import json
 
-
-import tenacity
 import magic
+import requests
+import tenacity
 from ostorlab.agent.kb import kb
+from ostorlab.agent.message import message as m
 from ostorlab.agent.mixins import (
     agent_report_vulnerability_mixin as vulnerability_mixin,
 )
-from ostorlab.agent.message import message as m
+from ostorlab.assets import android_store, harmonyos_store, ios_store
 from ostorlab.assets import asset as os_asset
-from ostorlab.assets import ios_store
-from ostorlab.assets import android_store
-from ostorlab.assets import harmonyos_store
 from ostorlab.assets import repository as repository_asset
 from ostorlab.assets import repository_archive as repository_archive_asset
-
 
 LINE_SIZE_MAX = 5000
 DOWNLOAD_REQUEST_TIMEOUT = 60

--- a/agent/utils.py
+++ b/agent/utils.py
@@ -65,9 +65,19 @@ def build_repository_archive_asset_directory(content_url: str) -> str:
         content_url: URL of the uploaded repository archive.
 
     Returns:
-        Last path segment of the archive content URL.
+        Path segment immediately after uploads, or the last path segment.
     """
     parsed_url: parse.ParseResult = parse.urlparse(content_url)
+    path_segments: list[str] = [
+        segment for segment in parsed_url.path.split("/") if len(segment) > 0
+    ]
+    try:
+        uploads_index: int = path_segments.index("uploads")
+    except ValueError:
+        return os.path.basename(parsed_url.path.rstrip("/"))
+
+    if uploads_index + 1 < len(path_segments):
+        return path_segments[uploads_index + 1]
     return os.path.basename(parsed_url.path.rstrip("/"))
 
 

--- a/agent/utils.py
+++ b/agent/utils.py
@@ -37,29 +37,27 @@ RISK_RATING_MAPPING = {
 logger = logging.getLogger(__name__)
 
 
-def build_repository_asset_directory(repository_url: str, commit_hash: str) -> str:
-    """Build the repository extraction folder name used in multi-asset scans.
+def construct_repository_asset_directory_name(
+    repository_url: str, commit_hash: str
+) -> str:
+    """Construct the repository extraction directory name used in multi-asset scans.
 
     Args:
         repository_url: URL of the repository asset.
         commit_hash: Commit hash checked out for the repository asset.
 
     Returns:
-        Folder name composed from the repository name and commit hash.
+        Directory name composed from the repository name and commit hash.
     """
     parsed_url: parse.ParseResult = parse.urlparse(repository_url)
-    repository_path: str = parsed_url.path
-    if len(repository_path) == 0:
-        repository_path = repository_url
-
-    repository_name: str = os.path.basename(repository_path.rstrip("/"))
+    repository_name: str = os.path.basename(parsed_url.path.rstrip("/"))
     if repository_name.endswith(".git") is True:
         repository_name = repository_name[: -len(".git")]
     return f"{repository_name}_{commit_hash}"
 
 
-def build_repository_archive_asset_directory(content_url: str) -> str:
-    """Build the archive extraction folder name from its uploaded content URL.
+def construct_repository_archive_asset_directory_name(content_url: str) -> str:
+    """Construct the archive extraction directory name from its uploaded content URL.
 
     Args:
         content_url: URL of the uploaded repository archive.

--- a/agent/utils.py
+++ b/agent/utils.py
@@ -59,11 +59,20 @@ def construct_repository_asset_directory_name(
 def construct_repository_archive_asset_directory_name(content_url: str) -> str:
     """Construct the archive extraction directory name from its uploaded content URL.
 
+    Repository archive uploads are expected to follow the GCS upload shape
+    `.../uploads/<uuid>`. The upload UUID immediately after the `uploads`
+    segment is returned and used as the extraction directory name.
+
     Args:
         content_url: URL of the uploaded repository archive.
 
     Returns:
-        Path segment immediately after uploads, or the last path segment.
+        The upload UUID segment immediately after `uploads`.
+
+    Raises:
+        ValueError: If `content_url` does not contain an `uploads/<uuid>`
+            segment, since any deviation from the expected upload shape must
+            surface rather than silently scan an ambiguous directory.
     """
     parsed_url: parse.ParseResult = parse.urlparse(content_url)
     path_segments: list[str] = [
@@ -72,11 +81,16 @@ def construct_repository_archive_asset_directory_name(content_url: str) -> str:
     try:
         uploads_index: int = path_segments.index("uploads")
     except ValueError:
-        return os.path.basename(parsed_url.path.rstrip("/"))
+        raise ValueError(
+            f"Repository archive content_url has no `uploads` segment: {content_url!r}"
+        )
 
-    if uploads_index + 1 < len(path_segments):
-        return path_segments[uploads_index + 1]
-    return os.path.basename(parsed_url.path.rstrip("/"))
+    if uploads_index + 1 >= len(path_segments):
+        raise ValueError(
+            f"Repository archive content_url has no upload id after `uploads`: "
+            f"{content_url!r}"
+        )
+    return path_segments[uploads_index + 1]
 
 
 def should_exclude_path(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,13 +1,13 @@
 """conftest for semgrep agent tests"""
 
 import json
-import random
 import pathlib
+import random
 from typing import Any, cast
 
 import pytest
-from ostorlab.agent.message import message
 from ostorlab.agent import definitions as agent_definitions
+from ostorlab.agent.message import message
 from ostorlab.runtimes import definitions as runtime_definitions
 from ostorlab.utils import definitions as utils_definitions
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -139,12 +139,18 @@ def scan_message_compressed_js_file() -> message.Message:
 
 
 @pytest.fixture
-def repository_asset_message() -> message.Message:
+def repository_commit_hash() -> str:
+    """Return a commit hash used by repository asset tests."""
+    return "a1a10cdbc6551ba359169a3033f193b7f8c1b95d"
+
+
+@pytest.fixture
+def repository_asset_message(repository_commit_hash: str) -> message.Message:
     """Creates a dummy message of type v3.asset.repository for testing purposes."""
     selector = "v3.asset.repository"
     msg_data = {
         "repository_url": "https://github.com/org/repo.git",
-        "commit_hash": "a1a10cdbc6551ba359169a3033f193b7f8c1b95d",
+        "commit_hash": repository_commit_hash,
         "provider": "GITHUB",
     }
     return message.Message.from_data(selector, data=msg_data)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -161,7 +161,7 @@ def repository_archive_asset_message() -> message.Message:
     """Creates a dummy message of type v3.asset.file.repository_archive for testing purposes."""
     selector = "v3.asset.file.repository_archive"
     msg_data = {
-        "content_url": "https://github.com/org/repo/archive/main.zip",
+        "content_url": "https://example.com/uploads/62f54a92-6d5f-4ce8-848e-adf13ff79fee",
         "path": "repo-main.zip",
     }
     return message.Message.from_data(selector, data=msg_data)

--- a/tests/semgrep_agent_test.py
+++ b/tests/semgrep_agent_test.py
@@ -488,6 +488,7 @@ def testAgentSemgrep_whenRepositoryAsset_emitsBackVulnerabilityWithRepositoryLoc
     agent_mock: list[message.Message],
     agent_persist_mock: dict[str | bytes, str | bytes],
     repository_asset_message: message.Message,
+    repository_commit_hash: str,
     mocker: plugin.MockerFixture,
 ) -> None:
     """Ensure repository assets are scanned and emit repository vulnerability location."""
@@ -503,7 +504,7 @@ def testAgentSemgrep_whenRepositoryAsset_emitsBackVulnerabilityWithRepositoryLoc
     assert vuln["vulnerability_location"] is not None
     assert vuln["vulnerability_location"]["repository"] == {
         "repository_url": "https://github.com/org/repo.git",
-        "commit_hash": "a1a10cdbc6551ba359169a3033f193b7f8c1b95d",
+        "commit_hash": repository_commit_hash,
         "provider": "GITHUB",
     }
     assert vuln["vulnerability_location"]["metadata"][0]["type"] == "FILE_PATH"
@@ -516,13 +517,14 @@ def testAgentSemgrep_whenRepositoryAsset_emitsBackVulnerabilityWithRepositoryLoc
 def testSemgrepAgent_whenRepositoryMessageHasNoProvider_shouldEmitVulnerabilityWithGitProvider(
     test_agent: semgrep_agent.SemgrepAgent,
     agent_mock: list[message.Message],
+    repository_commit_hash: str,
     mocker: plugin.MockerFixture,
 ) -> None:
     repository_asset_message = message.Message.from_data(
         "v3.asset.repository",
         data={
             "repository_url": "https://github.com/org/repo.git",
-            "commit_hash": "a1a10cdbc6551ba359169a3033f193b7f8c1b95d",
+            "commit_hash": repository_commit_hash,
         },
     )
 
@@ -540,7 +542,7 @@ def testSemgrepAgent_whenRepositoryMessageHasNoProvider_shouldEmitVulnerabilityW
     assert vuln["vulnerability_location"] is not None
     assert vuln["vulnerability_location"]["repository"] == {
         "repository_url": "https://github.com/org/repo.git",
-        "commit_hash": "a1a10cdbc6551ba359169a3033f193b7f8c1b95d",
+        "commit_hash": repository_commit_hash,
         "provider": "GIT",
     }
 
@@ -612,6 +614,7 @@ def testProcess_whenRepositoryAsset_shouldScanAssetDirectory(
     agent_mock: list[message.Message],
     agent_persist_mock: dict[str | bytes, str | bytes],
     repository_asset_message: message.Message,
+    repository_commit_hash: str,
     mocker: plugin.MockerFixture,
 ) -> None:
     """Ensure repository assets are scanned in their extracted asset directory."""
@@ -629,10 +632,7 @@ def testProcess_whenRepositoryAsset_shouldScanAssetDirectory(
 
     test_agent.process(repository_asset_message)
 
-    expected_scan_path: str = (
-        f"{semgrep_agent.ASSETS_CODE_PATH}/"
-        "repo_a1a10cdbc6551ba359169a3033f193b7f8c1b95d"
-    )
+    expected_scan_path: str = f"{semgrep_agent.ASSETS_CODE_PATH}/repo_{repository_commit_hash}"
     assert command_mock.call_args.args[0][-1] == expected_scan_path
 
 
@@ -649,7 +649,7 @@ def testProcess_whenRepositoryArchiveAsset_shouldScanAssetDirectory(
         selector="v3.asset.file.repository_archive",
         data={
             "content_url": (
-                "https://storage.googleapis.com/ostorlabapps/uploads/"
+                "https://example.com/uploads/"
                 "62f54a92-6d5f-4ce8-848e-adf13ff79fee"
             ),
             "path": "repo-main.zip",
@@ -671,6 +671,53 @@ def testProcess_whenRepositoryArchiveAsset_shouldScanAssetDirectory(
         f"{semgrep_agent.ASSETS_CODE_PATH}/62f54a92-6d5f-4ce8-848e-adf13ff79fee"
     )
     assert command_mock.call_args.args[0][-1] == expected_scan_path
+
+
+def testProcess_whenRepositoryAssetDirectoryEscapesAssetsCodePath_shouldNotScan(
+    test_agent: semgrep_agent.SemgrepAgent,
+    agent_mock: list[message.Message],
+    agent_persist_mock: dict[str | bytes, str | bytes],
+    mocker: plugin.MockerFixture,
+) -> None:
+    """Repository asset directories outside /code are rejected before scanning."""
+    del agent_mock
+    del agent_persist_mock
+    command_mock = mocker.patch("subprocess.run")
+    repository_asset_message: message.Message = message.Message.from_data(
+        selector="v3.asset.repository",
+        data={
+            "repository_url": "https://github.com/org/repo.git",
+            "commit_hash": "../secret",
+            "provider": "GITHUB",
+        },
+    )
+
+    test_agent.process(repository_asset_message)
+
+    command_mock.assert_not_called()
+
+
+def testProcess_whenRepositoryArchiveAssetDirectoryEscapesAssetsCodePath_shouldNotScan(
+    test_agent: semgrep_agent.SemgrepAgent,
+    agent_mock: list[message.Message],
+    agent_persist_mock: dict[str | bytes, str | bytes],
+    mocker: plugin.MockerFixture,
+) -> None:
+    """Repository archive asset directories outside /code are rejected before scanning."""
+    del agent_mock
+    del agent_persist_mock
+    command_mock = mocker.patch("subprocess.run")
+    repository_archive_asset_message: message.Message = message.Message.from_data(
+        selector="v3.asset.file.repository_archive",
+        data={
+            "content_url": "https://example.com/uploads/..",
+            "path": "repo-main.zip",
+        },
+    )
+
+    test_agent.process(repository_archive_asset_message)
+
+    command_mock.assert_not_called()
 
 
 def testAgentSemgrep_whenFilePathIsExcluded_notProcessMessage(

--- a/tests/semgrep_agent_test.py
+++ b/tests/semgrep_agent_test.py
@@ -520,6 +520,7 @@ def testSemgrepAgent_whenRepositoryMessageHasNoProvider_shouldEmitVulnerabilityW
     repository_commit_hash: str,
     mocker: plugin.MockerFixture,
 ) -> None:
+    """Repository assets without provider metadata default to a generic Git location."""
     repository_asset_message = message.Message.from_data(
         "v3.asset.repository",
         data={

--- a/tests/semgrep_agent_test.py
+++ b/tests/semgrep_agent_test.py
@@ -632,7 +632,9 @@ def testProcess_whenRepositoryAsset_shouldScanAssetDirectory(
 
     test_agent.process(repository_asset_message)
 
-    expected_scan_path: str = f"{semgrep_agent.ASSETS_CODE_PATH}/repo_{repository_commit_hash}"
+    expected_scan_path: str = (
+        f"{semgrep_agent.ASSETS_CODE_PATH}/repo_{repository_commit_hash}"
+    )
     assert command_mock.call_args.args[0][-1] == expected_scan_path
 
 
@@ -649,8 +651,7 @@ def testProcess_whenRepositoryArchiveAsset_shouldScanAssetDirectory(
         selector="v3.asset.file.repository_archive",
         data={
             "content_url": (
-                "https://example.com/uploads/"
-                "62f54a92-6d5f-4ce8-848e-adf13ff79fee"
+                "https://example.com/uploads/62f54a92-6d5f-4ce8-848e-adf13ff79fee"
             ),
             "path": "repo-main.zip",
         },

--- a/tests/semgrep_agent_test.py
+++ b/tests/semgrep_agent_test.py
@@ -668,8 +668,7 @@ def testProcess_whenRepositoryArchiveAsset_shouldScanAssetDirectory(
     test_agent.process(repository_archive_asset_message)
 
     expected_scan_path: str = (
-        f"{semgrep_agent.ASSETS_CODE_PATH}/"
-        "62f54a92-6d5f-4ce8-848e-adf13ff79fee"
+        f"{semgrep_agent.ASSETS_CODE_PATH}/62f54a92-6d5f-4ce8-848e-adf13ff79fee"
     )
     assert command_mock.call_args.args[0][-1] == expected_scan_path
 

--- a/tests/semgrep_agent_test.py
+++ b/tests/semgrep_agent_test.py
@@ -553,25 +553,37 @@ def testAgentSemgrep_whenRepositoryArchiveAsset_emitsBackVulnerabilityWithReposi
     mocker: plugin.MockerFixture,
 ) -> None:
     """Ensure repository archive assets emit a repository archive vulnerability location."""
+    del agent_mock
     del agent_persist_mock
+    report_vulnerability_mock = mocker.patch.object(test_agent, "report_vulnerability")
     mocker.patch(
-        "agent.semgrep_agent._run_analysis",
-        return_value=(JSON_OUTPUT, EMPTY_ERROR_MESSAGE),
+        "subprocess.run",
+        return_value=subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout=JSON_OUTPUT,
+            stderr=EMPTY_ERROR_MESSAGE,
+        ),
     )
 
     test_agent.process(repository_archive_asset_message)
 
-    vuln = agent_mock[0].data
-    assert vuln["vulnerability_location"] is not None
-    assert vuln["vulnerability_location"]["repository_archive"] == {
-        "content_url": "https://github.com/org/repo/archive/main.zip"
-    }
-    assert vuln["vulnerability_location"].get("repository") is None
-    assert vuln["vulnerability_location"]["metadata"][0]["type"] == "FILE_PATH"
+    vulnerability_location = report_vulnerability_mock.call_args.kwargs[
+        "vulnerability_location"
+    ]
+    assert vulnerability_location is not None
+    vulnerability_location_dict: dict[str, object] = vulnerability_location.to_dict()
+    repository_archive_location = vulnerability_location_dict["repository_archive"]
+    assert isinstance(repository_archive_location, dict)
     assert (
-        vuln["vulnerability_location"]["metadata"][0]["value"]
-        == "/tmp/tmpza6g8qu0.java"
+        repository_archive_location["content_url"]
+        == "https://github.com/org/repo/archive/main.zip"
     )
+    assert vulnerability_location_dict.get("repository") is None
+    metadata = vulnerability_location_dict["metadata"]
+    assert isinstance(metadata, list)
+    assert metadata[0]["type"] == "FILE_PATH"
+    assert metadata[0]["value"] == "/tmp/tmpza6g8qu0.java"
 
 
 def testAgentSemgrep_whenRepositoryArchiveAssetWithoutContentUrl_emitsBackVulnerabilityWithoutLocation(
@@ -595,23 +607,71 @@ def testAgentSemgrep_whenRepositoryArchiveAssetWithoutContentUrl_emitsBackVulner
     assert agent_mock[0].data.get("vulnerability_location") is None
 
 
-def testAgentSemgrep_whenRepositoryArchiveAsset_scansSharedCodeVolume(
+def testProcess_whenRepositoryAsset_shouldScanAssetDirectory(
     test_agent: semgrep_agent.SemgrepAgent,
     agent_mock: list[message.Message],
     agent_persist_mock: dict[str | bytes, str | bytes],
-    repository_archive_asset_message: message.Message,
+    repository_asset_message: message.Message,
     mocker: plugin.MockerFixture,
 ) -> None:
-    """Ensure repository archive assets are scanned on the shared /code volume."""
+    """Ensure repository assets are scanned in their extracted asset directory."""
+    del agent_mock
     del agent_persist_mock
-    run_analysis_mock = mocker.patch(
-        "agent.semgrep_agent._run_analysis",
-        return_value=(JSON_OUTPUT, EMPTY_ERROR_MESSAGE),
+    command_mock = mocker.patch(
+        "subprocess.run",
+        return_value=subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout=EMPTY_JSON_OUTPUT,
+            stderr=EMPTY_ERROR_MESSAGE,
+        ),
+    )
+
+    test_agent.process(repository_asset_message)
+
+    expected_scan_path: str = (
+        f"{semgrep_agent.ASSETS_CODE_PATH}/"
+        "repo_a1a10cdbc6551ba359169a3033f193b7f8c1b95d"
+    )
+    assert command_mock.call_args.args[0][-1] == expected_scan_path
+
+
+def testProcess_whenRepositoryArchiveAsset_shouldScanAssetDirectory(
+    test_agent: semgrep_agent.SemgrepAgent,
+    agent_mock: list[message.Message],
+    agent_persist_mock: dict[str | bytes, str | bytes],
+    mocker: plugin.MockerFixture,
+) -> None:
+    """Ensure repository archive assets are scanned in their extracted asset directory."""
+    del agent_mock
+    del agent_persist_mock
+    repository_archive_asset_message: message.Message = message.Message.from_data(
+        selector="v3.asset.file.repository_archive",
+        data={
+            "content_url": (
+                "https://storage.googleapis.com/ostorlabapps/uploads/"
+                "62f54a92-6d5f-4ce8-848e-adf13ff79fee"
+            ),
+            "path": "repo-main.zip",
+        },
+    )
+    command_mock = mocker.patch(
+        "subprocess.run",
+        return_value=subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout=EMPTY_JSON_OUTPUT,
+            stderr=EMPTY_ERROR_MESSAGE,
+        ),
     )
 
     test_agent.process(repository_archive_asset_message)
 
-    assert run_analysis_mock.call_args.args[0] == semgrep_agent.REPOSITORY_CODE_PATH
+    expected_scan_path: str = (
+        f"{semgrep_agent.ASSETS_CODE_PATH}/"
+        "62f54a92-6d5f-4ce8-848e-adf13ff79fee"
+    )
+    assert command_mock.call_args.args[0][-1] == expected_scan_path
 
 
 def testAgentSemgrep_whenFilePathIsExcluded_notProcessMessage(

--- a/tests/semgrep_agent_test.py
+++ b/tests/semgrep_agent_test.py
@@ -580,7 +580,7 @@ def testAgentSemgrep_whenRepositoryArchiveAsset_emitsBackVulnerabilityWithReposi
     assert isinstance(repository_archive_location, dict)
     assert (
         repository_archive_location["content_url"]
-        == "https://github.com/org/repo/archive/main.zip"
+        == "https://example.com/uploads/62f54a92-6d5f-4ce8-848e-adf13ff79fee"
     )
     assert vulnerability_location_dict.get("repository") is None
     metadata = vulnerability_location_dict["metadata"]
@@ -589,25 +589,23 @@ def testAgentSemgrep_whenRepositoryArchiveAsset_emitsBackVulnerabilityWithReposi
     assert metadata[0]["value"] == "/tmp/tmpza6g8qu0.java"
 
 
-def testAgentSemgrep_whenRepositoryArchiveAssetWithoutContentUrl_emitsBackVulnerabilityWithoutLocation(
+def testProcess_whenRepositoryArchiveAssetWithoutContentUrl_shouldNotScan(
     test_agent: semgrep_agent.SemgrepAgent,
     agent_mock: list[message.Message],
     agent_persist_mock: dict[str | bytes, str | bytes],
     repository_archive_asset_message_without_content_url: message.Message,
     mocker: plugin.MockerFixture,
 ) -> None:
-    """A malformed archive message without a content url cannot identify the asset, the vulnerability
-    is still reported but with no location."""
+    """A repository archive asset without a content_url is refused and never scanned."""
     del agent_persist_mock
-    mocker.patch(
-        "agent.semgrep_agent._run_analysis",
-        return_value=(JSON_OUTPUT, EMPTY_ERROR_MESSAGE),
-    )
+    command_mock = mocker.patch("subprocess.run")
+    run_analysis_mock = mocker.patch("agent.semgrep_agent._run_analysis")
 
     test_agent.process(repository_archive_asset_message_without_content_url)
 
-    assert len(agent_mock) > 0
-    assert agent_mock[0].data.get("vulnerability_location") is None
+    command_mock.assert_not_called()
+    run_analysis_mock.assert_not_called()
+    assert len(agent_mock) == 0
 
 
 def testProcess_whenRepositoryAsset_shouldScanAssetDirectory(
@@ -722,25 +720,17 @@ def testProcess_whenRepositoryArchiveAssetDirectoryEscapesAssetsCodePath_shouldN
     command_mock.assert_not_called()
 
 
-def testProcess_whenRepositoryAssetHasEmptyUrlOrCommitHash_shouldFallBackToSharedCodePath(
+def testProcess_whenRepositoryAssetHasEmptyUrl_shouldNotScan(
     test_agent: semgrep_agent.SemgrepAgent,
     agent_mock: list[message.Message],
     agent_persist_mock: dict[str | bytes, str | bytes],
     repository_commit_hash: str,
     mocker: plugin.MockerFixture,
 ) -> None:
-    """Empty repository_url or commit_hash fall back to the shared /code path."""
+    """An empty repository_url is refused rather than falling back to the shared /code root."""
     del agent_mock
     del agent_persist_mock
-    command_mock = mocker.patch(
-        "subprocess.run",
-        return_value=subprocess.CompletedProcess(
-            args=[],
-            returncode=0,
-            stdout=EMPTY_JSON_OUTPUT,
-            stderr=EMPTY_ERROR_MESSAGE,
-        ),
-    )
+    command_mock = mocker.patch("subprocess.run")
     repository_asset_message = message.Message.from_data(
         selector="v3.asset.repository",
         data={"repository_url": "", "commit_hash": repository_commit_hash},
@@ -748,27 +738,60 @@ def testProcess_whenRepositoryAssetHasEmptyUrlOrCommitHash_shouldFallBackToShare
 
     test_agent.process(repository_asset_message)
 
-    assert command_mock.call_args.args[0][-1] == semgrep_agent.ASSETS_CODE_PATH
+    command_mock.assert_not_called()
 
 
-def testProcess_whenRepositoryArchiveAssetHasEmptyContentUrl_shouldFallBackToSharedCodePath(
+def testProcess_whenRepositoryAssetHasEmptyCommitHash_shouldNotScan(
     test_agent: semgrep_agent.SemgrepAgent,
     agent_mock: list[message.Message],
     agent_persist_mock: dict[str | bytes, str | bytes],
     mocker: plugin.MockerFixture,
 ) -> None:
-    """An empty content_url falls back to the shared /code path instead of scanning silently."""
+    """An empty commit_hash is refused rather than falling back to the shared /code root."""
     del agent_mock
     del agent_persist_mock
-    command_mock = mocker.patch(
-        "subprocess.run",
-        return_value=subprocess.CompletedProcess(
-            args=[],
-            returncode=0,
-            stdout=EMPTY_JSON_OUTPUT,
-            stderr=EMPTY_ERROR_MESSAGE,
-        ),
+    command_mock = mocker.patch("subprocess.run")
+    repository_asset_message = message.Message.from_data(
+        selector="v3.asset.repository",
+        data={"repository_url": "https://github.com/org/repo.git", "commit_hash": ""},
     )
+
+    test_agent.process(repository_asset_message)
+
+    command_mock.assert_not_called()
+
+
+def testProcess_whenRepositoryAssetHasMissingUrl_shouldNotScan(
+    test_agent: semgrep_agent.SemgrepAgent,
+    agent_mock: list[message.Message],
+    agent_persist_mock: dict[str | bytes, str | bytes],
+    repository_commit_hash: str,
+    mocker: plugin.MockerFixture,
+) -> None:
+    """A repository asset with no repository_url at all is refused before scanning."""
+    del agent_mock
+    del agent_persist_mock
+    command_mock = mocker.patch("subprocess.run")
+    repository_asset_message = message.Message.from_data(
+        selector="v3.asset.repository",
+        data={"commit_hash": repository_commit_hash},
+    )
+
+    test_agent.process(repository_asset_message)
+
+    command_mock.assert_not_called()
+
+
+def testProcess_whenRepositoryArchiveAssetHasEmptyContentUrl_shouldNotScan(
+    test_agent: semgrep_agent.SemgrepAgent,
+    agent_mock: list[message.Message],
+    agent_persist_mock: dict[str | bytes, str | bytes],
+    mocker: plugin.MockerFixture,
+) -> None:
+    """An empty content_url is refused rather than scanning the shared /code root silently."""
+    del agent_mock
+    del agent_persist_mock
+    command_mock = mocker.patch("subprocess.run")
     repository_archive_asset_message = message.Message.from_data(
         selector="v3.asset.file.repository_archive",
         data={"content_url": "", "path": "repo-main.zip"},
@@ -776,7 +799,30 @@ def testProcess_whenRepositoryArchiveAssetHasEmptyContentUrl_shouldFallBackToSha
 
     test_agent.process(repository_archive_asset_message)
 
-    assert command_mock.call_args.args[0][-1] == semgrep_agent.ASSETS_CODE_PATH
+    command_mock.assert_not_called()
+
+
+def testProcess_whenRepositoryArchiveAssetHasMalformedContentUrl_shouldNotScan(
+    test_agent: semgrep_agent.SemgrepAgent,
+    agent_mock: list[message.Message],
+    agent_persist_mock: dict[str | bytes, str | bytes],
+    mocker: plugin.MockerFixture,
+) -> None:
+    """A content_url that does not follow the `uploads/<uuid>` shape is refused and never scanned."""
+    del agent_mock
+    del agent_persist_mock
+    command_mock = mocker.patch("subprocess.run")
+    repository_archive_asset_message = message.Message.from_data(
+        selector="v3.asset.file.repository_archive",
+        data={
+            "content_url": "https://github.com/org/repo/archive/main.zip",
+            "path": "repo-main.zip",
+        },
+    )
+
+    test_agent.process(repository_archive_asset_message)
+
+    command_mock.assert_not_called()
 
 
 def testProcess_whenRepositoryUrlHasNoPath_shouldRejectInvalidAssetDirectoryAndNotScan(
@@ -804,19 +850,16 @@ def testProcess_whenRepositoryUrlHasNoPath_shouldRejectInvalidAssetDirectoryAndN
     command_mock.assert_not_called()
 
 
-def testProcess_whenRepositoryAssetHasEmptyUrl_emitsVulnerabilityWithoutRepositoryLocation(
+def testProcess_whenRepositoryAssetHasInvalidValues_shouldNotEmitVulnerability(
     test_agent: semgrep_agent.SemgrepAgent,
     agent_mock: list[message.Message],
     agent_persist_mock: dict[str | bytes, str | bytes],
     repository_commit_hash: str,
     mocker: plugin.MockerFixture,
 ) -> None:
-    """An empty repository_url is normalized to None so no repository asset is attached to the location."""
+    """A repository asset refused for missing metadata emits no vulnerability at all."""
     del agent_persist_mock
-    mocker.patch(
-        "agent.semgrep_agent._run_analysis",
-        return_value=(JSON_OUTPUT, EMPTY_ERROR_MESSAGE),
-    )
+    mocker.patch("agent.semgrep_agent._run_analysis")
     repository_asset_message = message.Message.from_data(
         selector="v3.asset.repository",
         data={"repository_url": "", "commit_hash": repository_commit_hash},
@@ -824,8 +867,7 @@ def testProcess_whenRepositoryAssetHasEmptyUrl_emitsVulnerabilityWithoutReposito
 
     test_agent.process(repository_asset_message)
 
-    assert len(agent_mock) > 0
-    assert agent_mock[0].data.get("vulnerability_location") is None
+    assert len(agent_mock) == 0
 
 
 def testAgentSemgrep_whenFilePathIsExcluded_notProcessMessage(

--- a/tests/semgrep_agent_test.py
+++ b/tests/semgrep_agent_test.py
@@ -779,6 +779,55 @@ def testProcess_whenRepositoryArchiveAssetHasEmptyContentUrl_shouldFallBackToSha
     assert command_mock.call_args.args[0][-1] == semgrep_agent.ASSETS_CODE_PATH
 
 
+def testProcess_whenRepositoryUrlHasNoPath_shouldRejectInvalidAssetDirectoryAndNotScan(
+    test_agent: semgrep_agent.SemgrepAgent,
+    agent_mock: list[message.Message],
+    agent_persist_mock: dict[str | bytes, str | bytes],
+    repository_commit_hash: str,
+    mocker: plugin.MockerFixture,
+) -> None:
+    """A repository URL with no path yields a directory name starting with `_` that is rejected."""
+    del agent_mock
+    del agent_persist_mock
+    command_mock = mocker.patch("subprocess.run")
+    repository_asset_message = message.Message.from_data(
+        selector="v3.asset.repository",
+        data={
+            "repository_url": "https://github.com",
+            "commit_hash": repository_commit_hash,
+            "provider": "GITHUB",
+        },
+    )
+
+    test_agent.process(repository_asset_message)
+
+    command_mock.assert_not_called()
+
+
+def testProcess_whenRepositoryAssetHasEmptyUrl_emitsVulnerabilityWithoutRepositoryLocation(
+    test_agent: semgrep_agent.SemgrepAgent,
+    agent_mock: list[message.Message],
+    agent_persist_mock: dict[str | bytes, str | bytes],
+    repository_commit_hash: str,
+    mocker: plugin.MockerFixture,
+) -> None:
+    """An empty repository_url is normalized to None so no repository asset is attached to the location."""
+    del agent_persist_mock
+    mocker.patch(
+        "agent.semgrep_agent._run_analysis",
+        return_value=(JSON_OUTPUT, EMPTY_ERROR_MESSAGE),
+    )
+    repository_asset_message = message.Message.from_data(
+        selector="v3.asset.repository",
+        data={"repository_url": "", "commit_hash": repository_commit_hash},
+    )
+
+    test_agent.process(repository_asset_message)
+
+    assert len(agent_mock) > 0
+    assert agent_mock[0].data.get("vulnerability_location") is None
+
+
 def testAgentSemgrep_whenFilePathIsExcluded_notProcessMessage(
     test_agent_with_exclude_path_regexes: semgrep_agent.SemgrepAgent,
     agent_mock: list[message.Message],

--- a/tests/semgrep_agent_test.py
+++ b/tests/semgrep_agent_test.py
@@ -722,6 +722,63 @@ def testProcess_whenRepositoryArchiveAssetDirectoryEscapesAssetsCodePath_shouldN
     command_mock.assert_not_called()
 
 
+def testProcess_whenRepositoryAssetHasEmptyUrlOrCommitHash_shouldFallBackToSharedCodePath(
+    test_agent: semgrep_agent.SemgrepAgent,
+    agent_mock: list[message.Message],
+    agent_persist_mock: dict[str | bytes, str | bytes],
+    repository_commit_hash: str,
+    mocker: plugin.MockerFixture,
+) -> None:
+    """Empty repository_url or commit_hash fall back to the shared /code path."""
+    del agent_mock
+    del agent_persist_mock
+    command_mock = mocker.patch(
+        "subprocess.run",
+        return_value=subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout=EMPTY_JSON_OUTPUT,
+            stderr=EMPTY_ERROR_MESSAGE,
+        ),
+    )
+    repository_asset_message = message.Message.from_data(
+        selector="v3.asset.repository",
+        data={"repository_url": "", "commit_hash": repository_commit_hash},
+    )
+
+    test_agent.process(repository_asset_message)
+
+    assert command_mock.call_args.args[0][-1] == semgrep_agent.ASSETS_CODE_PATH
+
+
+def testProcess_whenRepositoryArchiveAssetHasEmptyContentUrl_shouldFallBackToSharedCodePath(
+    test_agent: semgrep_agent.SemgrepAgent,
+    agent_mock: list[message.Message],
+    agent_persist_mock: dict[str | bytes, str | bytes],
+    mocker: plugin.MockerFixture,
+) -> None:
+    """An empty content_url falls back to the shared /code path instead of scanning silently."""
+    del agent_mock
+    del agent_persist_mock
+    command_mock = mocker.patch(
+        "subprocess.run",
+        return_value=subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout=EMPTY_JSON_OUTPUT,
+            stderr=EMPTY_ERROR_MESSAGE,
+        ),
+    )
+    repository_archive_asset_message = message.Message.from_data(
+        selector="v3.asset.file.repository_archive",
+        data={"content_url": "", "path": "repo-main.zip"},
+    )
+
+    test_agent.process(repository_archive_asset_message)
+
+    assert command_mock.call_args.args[0][-1] == semgrep_agent.ASSETS_CODE_PATH
+
+
 def testAgentSemgrep_whenFilePathIsExcluded_notProcessMessage(
     test_agent_with_exclude_path_regexes: semgrep_agent.SemgrepAgent,
     agent_mock: list[message.Message],

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -246,6 +246,16 @@ def testBuildRepositoryArchiveAssetDirectory_whenContentUrlHasQueryString_return
     assert asset_directory == "cc3714"
 
 
+def testBuildRepositoryArchiveAssetDirectory_whenUploadUrlHasPathAfterId_returnsUploadId() -> (
+    None
+):
+    content_url = "https://example.com/uploads/cc3714/archive/main.zip"
+
+    asset_directory = utils.build_repository_archive_asset_directory(content_url)
+
+    assert asset_directory == "cc3714"
+
+
 def testShouldExcludePath_whenPathMatchesWorkspacePattern_shouldReturnTrue() -> None:
     result = utils.should_exclude_path("/workspace/src/main.py", [r"^/workspace(/|$)"])
 

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -239,9 +239,7 @@ def testBuildRepositoryAssetDirectory_whenRepositoryUrlHasSuffixes_returnsAssetD
 def testBuildRepositoryArchiveAssetDirectory_whenContentUrlHasQueryString_returnsAssetDirectory() -> (
     None
 ):
-    content_url = (
-        "https://example.com/uploads/cc3714?X-Goog-Algorithm=GOO"
-    )
+    content_url = "https://example.com/uploads/cc3714?X-Goog-Algorithm=GOO"
 
     asset_directory = utils.build_repository_archive_asset_directory(content_url)
 

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -229,6 +229,7 @@ def testBuildRepositoryAssetDirectory_whenRepositoryUrlHasSuffixes_returnsAssetD
     expected_repository_name: str,
     repository_commit_hash: str,
 ) -> None:
+    """Repository URLs with .git or trailing slash use the bare repo name."""
     asset_directory = utils.build_repository_asset_directory(
         repository_url, repository_commit_hash
     )
@@ -239,6 +240,7 @@ def testBuildRepositoryAssetDirectory_whenRepositoryUrlHasSuffixes_returnsAssetD
 def testBuildRepositoryArchiveAssetDirectory_whenContentUrlHasQueryString_returnsAssetDirectory() -> (
     None
 ):
+    """Archive content URL query strings are ignored when deriving the directory."""
     content_url = "https://example.com/uploads/cc3714?X-Goog-Algorithm=GOO"
 
     asset_directory = utils.build_repository_archive_asset_directory(content_url)
@@ -249,6 +251,7 @@ def testBuildRepositoryArchiveAssetDirectory_whenContentUrlHasQueryString_return
 def testBuildRepositoryArchiveAssetDirectory_whenUploadUrlHasPathAfterId_returnsUploadId() -> (
     None
 ):
+    """Archive content URLs with extra path segments use the upload id."""
     content_url = "https://example.com/uploads/cc3714/archive/main.zip"
 
     asset_directory = utils.build_repository_archive_asset_directory(content_url)

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -1,9 +1,9 @@
 """Unittests for Semgrep Agent Utilities"""
 
 from typing import Any
-import requests
 
 import pytest
+import requests
 import requests_mock as reqs_mock
 from ostorlab.agent.message import message as m
 

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -211,6 +211,43 @@ def testGetFileContent_whenNoContentIsAvailable_shouldReturnNone() -> None:
     assert content is None
 
 
+@pytest.mark.parametrize(
+    ("repository_url", "expected_repository_name"),
+    [
+        (
+            "https://github.com/org/repo.git",
+            "repo",
+        ),
+        (
+            "https://github.com/org/repo/",
+            "repo",
+        ),
+    ],
+)
+def testBuildRepositoryAssetDirectory_whenRepositoryUrlHasSuffixes_returnsAssetDirectory(
+    repository_url: str,
+    expected_repository_name: str,
+    repository_commit_hash: str,
+) -> None:
+    asset_directory = utils.build_repository_asset_directory(
+        repository_url, repository_commit_hash
+    )
+
+    assert asset_directory == f"{expected_repository_name}_{repository_commit_hash}"
+
+
+def testBuildRepositoryArchiveAssetDirectory_whenContentUrlHasQueryString_returnsAssetDirectory() -> (
+    None
+):
+    content_url = (
+        "https://example.com/uploads/cc3714?X-Goog-Algorithm=GOO"
+    )
+
+    asset_directory = utils.build_repository_archive_asset_directory(content_url)
+
+    assert asset_directory == "cc3714"
+
+
 def testShouldExcludePath_whenPathMatchesWorkspacePattern_shouldReturnTrue() -> None:
     result = utils.should_exclude_path("/workspace/src/main.py", [r"^/workspace(/|$)"])
 

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -276,6 +276,19 @@ def testConstructRepositoryArchiveAssetDirectoryName_whenUploadUrlHasPathAfterId
     assert asset_directory == "cc3714"
 
 
+def testConstructRepositoryArchiveAssetDirectoryName_whenContentUrlHasNoUploadsSegment_returnsLastPathSegment() -> (
+    None
+):
+    """Archive content URLs without an uploads segment fall back to the last path segment."""
+    content_url = "https://github.com/org/repo/archive/main.zip"
+
+    asset_directory = utils.construct_repository_archive_asset_directory_name(
+        content_url
+    )
+
+    assert asset_directory == "main.zip"
+
+
 def testShouldExcludePath_whenPathMatchesWorkspacePattern_shouldReturnTrue() -> None:
     result = utils.should_exclude_path("/workspace/src/main.py", [r"^/workspace(/|$)"])
 

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -276,17 +276,24 @@ def testConstructRepositoryArchiveAssetDirectoryName_whenUploadUrlHasPathAfterId
     assert asset_directory == "cc3714"
 
 
-def testConstructRepositoryArchiveAssetDirectoryName_whenContentUrlHasNoUploadsSegment_returnsLastPathSegment() -> (
+def testConstructRepositoryArchiveAssetDirectoryName_whenContentUrlHasNoUploadsSegment_raisesValueError() -> (
     None
 ):
-    """Archive content URLs without an uploads segment fall back to the last path segment."""
+    """Archive content URLs without an `uploads` segment are rejected, not silently accepted."""
     content_url = "https://github.com/org/repo/archive/main.zip"
 
-    asset_directory = utils.construct_repository_archive_asset_directory_name(
-        content_url
-    )
+    with pytest.raises(ValueError):
+        utils.construct_repository_archive_asset_directory_name(content_url)
 
-    assert asset_directory == "main.zip"
+
+def testConstructRepositoryArchiveAssetDirectoryName_whenUploadsHasNoIdAfter_raisesValueError() -> (
+    None
+):
+    """Archive content URLs ending at `uploads` with no following id are rejected."""
+    content_url = "https://example.com/uploads"
+
+    with pytest.raises(ValueError):
+        utils.construct_repository_archive_asset_directory_name(content_url)
 
 
 def testShouldExcludePath_whenPathMatchesWorkspacePattern_shouldReturnTrue() -> None:

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -224,37 +224,54 @@ def testGetFileContent_whenNoContentIsAvailable_shouldReturnNone() -> None:
         ),
     ],
 )
-def testBuildRepositoryAssetDirectory_whenRepositoryUrlHasSuffixes_returnsAssetDirectory(
+def testConstructRepositoryAssetDirectoryName_whenRepositoryUrlHasSuffixes_returnsAssetDirectory(
     repository_url: str,
     expected_repository_name: str,
     repository_commit_hash: str,
 ) -> None:
     """Repository URLs with .git or trailing slash use the bare repo name."""
-    asset_directory = utils.build_repository_asset_directory(
+    asset_directory = utils.construct_repository_asset_directory_name(
         repository_url, repository_commit_hash
     )
 
     assert asset_directory == f"{expected_repository_name}_{repository_commit_hash}"
 
 
-def testBuildRepositoryArchiveAssetDirectory_whenContentUrlHasQueryString_returnsAssetDirectory() -> (
+def testConstructRepositoryAssetDirectoryName_whenRepositoryUrlHasNoSuffix_returnsAssetDirectory(
+    repository_commit_hash: str,
+) -> None:
+    """Repository URLs without .git or trailing slash still derive the repo name."""
+    repository_url = "https://github.com/org/repo"
+
+    asset_directory = utils.construct_repository_asset_directory_name(
+        repository_url, repository_commit_hash
+    )
+
+    assert asset_directory == f"repo_{repository_commit_hash}"
+
+
+def testConstructRepositoryArchiveAssetDirectoryName_whenContentUrlHasQueryString_returnsAssetDirectory() -> (
     None
 ):
     """Archive content URL query strings are ignored when deriving the directory."""
     content_url = "https://example.com/uploads/cc3714?X-Goog-Algorithm=GOO"
 
-    asset_directory = utils.build_repository_archive_asset_directory(content_url)
+    asset_directory = utils.construct_repository_archive_asset_directory_name(
+        content_url
+    )
 
     assert asset_directory == "cc3714"
 
 
-def testBuildRepositoryArchiveAssetDirectory_whenUploadUrlHasPathAfterId_returnsUploadId() -> (
+def testConstructRepositoryArchiveAssetDirectoryName_whenUploadUrlHasPathAfterId_returnsUploadId() -> (
     None
 ):
     """Archive content URLs with extra path segments use the upload id."""
     content_url = "https://example.com/uploads/cc3714/archive/main.zip"
 
-    asset_directory = utils.build_repository_archive_asset_directory(content_url)
+    asset_directory = utils.construct_repository_archive_asset_directory_name(
+        content_url
+    )
 
     assert asset_directory == "cc3714"
 


### PR DESCRIPTION
Updates the Semgrep agent to scan the selected repository-like asset directory instead of always scanning the shared `/code` root.

### Changes:
- Derive repository asset scan paths as `/code/<repo_name>_<commit_hash>`.
- Derive repository archive scan paths from the uploaded archive `content_url` UUID `/code/UUID` .
- Rename `REPOSITORY_CODE_PATH` to `ASSETS_CODE_PATH`.
- Add utility helpers for repository and repository archive extraction directory names.